### PR TITLE
enable reading from streams that don't report `.Length` and `.Position`

### DIFF
--- a/src/IxMilia.Dxf.Test/IxMilia.Dxf.Test.csproj
+++ b/src/IxMilia.Dxf.Test/IxMilia.Dxf.Test.csproj
@@ -36,6 +36,7 @@
     <Compile Include="DxfHeaderTests.cs" />
     <Compile Include="DxfReaderWriterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StreamWithNoLengthOrPosition.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="diamond-bin.dxf">

--- a/src/IxMilia.Dxf.Test/StreamWithNoLengthOrPosition.cs
+++ b/src/IxMilia.Dxf.Test/StreamWithNoLengthOrPosition.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) IxMilia.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace IxMilia.Dxf.Test
+{
+    internal class StreamWithNoLengthOrPosition : Stream
+    {
+        public Stream BaseStream { get; }
+
+        public StreamWithNoLengthOrPosition(Stream baseStream)
+        {
+            BaseStream = baseStream;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return BaseStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/IxMilia.Dxf/DxfBinaryReader.cs
+++ b/src/IxMilia.Dxf/DxfBinaryReader.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) IxMilia.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -33,67 +34,205 @@ namespace IxMilia.Dxf
 
         private DxfCodePair GetCodePair()
         {
-            if (CanRead())
-            {
-                var codeOffset = (int)_reader.BaseStream.Position;
-                var code = ReadCode();
-                var expectedType = DxfCodePair.ExpectedType(code);
-                DxfCodePair pair;
-                if (expectedType == typeof(short))
-                {
-                    pair = new DxfCodePair(code, _reader.ReadInt16());
-                }
-                else if (expectedType == typeof(double))
-                {
-                    pair = new DxfCodePair(code, _reader.ReadDouble());
-                }
-                else if (expectedType == typeof(int))
-                {
-                    pair = new DxfCodePair(code, _reader.ReadInt32());
-                }
-                else if (expectedType == typeof(long))
-                {
-                    pair = new DxfCodePair(code, _reader.ReadInt64());
-                }
-                else if (expectedType == typeof(string))
-                {
-                    var sb = new StringBuilder();
-                    for (int b = _reader.Read(); b != 0; b = _reader.Read())
-                        sb.Append((char)b);
-                    pair = new DxfCodePair(code, DxfReader.TransformControlCharacters(sb.ToString()));
-                }
-                else if (expectedType == typeof(bool))
-                {
-                    pair = new DxfCodePair(code, _reader.ReadInt16() != 0);
-                }
-                else
-                {
-                    throw new DxfReadException("Unsupported code " + code, codeOffset);
-                }
-
-                pair.Offset = codeOffset;
-                return pair;
-            }
-            else
+            var codeOffset = _totalBytesRead + _miniBufferStart;
+            int code;
+            if (!TryReadCode(out code))
             {
                 return null;
             }
-        }
 
-        private int ReadCode()
-        {
-            int code = _reader.ReadByte();
-            if (code == 255)
+            var expectedType = DxfCodePair.ExpectedType(code);
+            DxfCodePair pair;
+            if (expectedType == typeof(short))
             {
-                code = _reader.ReadInt16();
+                short s;
+                if (!TryReadInt16(out s))
+                {
+                    return null;
+                }
+
+                pair = new DxfCodePair(code, s);
+            }
+            else if (expectedType == typeof(double))
+            {
+                double d;
+                if (!TryReadDouble(out d))
+                {
+                    return null;
+                }
+
+                pair = new DxfCodePair(code, d);
+            }
+            else if (expectedType == typeof(int))
+            {
+                int i;
+                if (!TryReadInt32(out i))
+                {
+                    return null;
+                }
+
+                pair = new DxfCodePair(code, i);
+            }
+            else if (expectedType == typeof(long))
+            {
+                long l;
+                if (!TryReadInt64(out l))
+                {
+                    return null;
+                }
+
+                pair = new DxfCodePair(code, l);
+            }
+            else if (expectedType == typeof(string))
+            {
+                var sb = new StringBuilder();
+                byte b;
+                for (; TryReadByte(out b) && b != 0;)
+                {
+                    sb.Append((char)b);
+                }
+
+                pair = new DxfCodePair(code, DxfReader.TransformControlCharacters(sb.ToString()));
+            }
+            else if (expectedType == typeof(bool))
+            {
+                bool b;
+                if (!TryReadBool(out b))
+                {
+                    return null;
+                }
+
+                pair = new DxfCodePair(code, b);
+            }
+            else
+            {
+                throw new DxfReadException("Unsupported code " + code, codeOffset);
             }
 
-            return code;
+            pair.Offset = codeOffset;
+            return pair;
         }
 
-        private bool CanRead()
+        private bool TryReadCode(out int code)
         {
-            return _reader.BaseStream.Position < _reader.BaseStream.Length;
+            code = default(int);
+            byte b;
+            if (!TryReadByte(out b))
+            {
+                return false;
+            }
+
+            if (b == 255)
+            {
+                short s;
+                if (!TryReadInt16(out s))
+                {
+                    return false;
+                }
+
+                code = s;
+            }
+            else
+            {
+                code = b;
+            }
+
+            return true;
+        }
+
+        // Since we can't reliably call `_reader.BaseStream.Position` and `.Length`, we instead use the `Stream.Read(byte[], int, int)`
+        // method to continually fill a local buffer.
+        byte[] _miniBuffer = new byte[8];
+        int _miniBufferStart = 0;
+        int _miniBufferEnd = 0;
+        int _totalBytesRead = 22;
+        byte[] _dataBuffer = new byte[8];
+
+        private bool TryReadByte(out byte result)
+        {
+            if (_miniBufferEnd - _miniBufferStart < 1)
+            {
+                _totalBytesRead += _miniBufferEnd;
+                _miniBufferStart = 0;
+                _miniBufferEnd = _reader.BaseStream.Read(_miniBuffer, 0, _miniBuffer.Length);
+            }
+
+            if (_miniBufferEnd == 0)
+            {
+                result = default(byte);
+                return false;
+            }
+
+            result = _miniBuffer[_miniBufferStart++];
+            return true;
+        }
+
+        private bool TryReadInt16(out short result)
+        {
+            if (TryReadByte(out _dataBuffer[0]) && TryReadByte(out _dataBuffer[1]))
+            {
+                result = BitConverter.ToInt16(_dataBuffer, 0);
+                return true;
+            }
+
+            result = default(short);
+            return false;
+        }
+
+        private bool TryReadBool(out bool result)
+        {
+            short s;
+            if (TryReadInt16(out s))
+            {
+                result = s != 0;
+                return true;
+            }
+
+            result = default(bool);
+            return false;
+        }
+
+        private bool TryReadInt32(out int result)
+        {
+            if (TryReadByte(out _dataBuffer[0]) && TryReadByte(out _dataBuffer[1]) &&
+                TryReadByte(out _dataBuffer[2]) && TryReadByte(out _dataBuffer[3]))
+            {
+                result = BitConverter.ToInt32(_dataBuffer, 0);
+                return true;
+            }
+
+            result = default(int);
+            return false;
+        }
+
+        private bool TryReadInt64(out long result)
+        {
+            if (TryReadByte(out _dataBuffer[0]) && TryReadByte(out _dataBuffer[1]) &&
+                TryReadByte(out _dataBuffer[2]) && TryReadByte(out _dataBuffer[3]) &&
+                TryReadByte(out _dataBuffer[4]) && TryReadByte(out _dataBuffer[5]) &&
+                TryReadByte(out _dataBuffer[6]) && TryReadByte(out _dataBuffer[7]))
+            {
+                result = BitConverter.ToInt64(_dataBuffer, 0);
+                return true;
+            }
+
+            result = default(long);
+            return false;
+        }
+
+        private bool TryReadDouble(out double result)
+        {
+            if (TryReadByte(out _dataBuffer[0]) && TryReadByte(out _dataBuffer[1]) &&
+                TryReadByte(out _dataBuffer[2]) && TryReadByte(out _dataBuffer[3]) &&
+                TryReadByte(out _dataBuffer[4]) && TryReadByte(out _dataBuffer[5]) &&
+                TryReadByte(out _dataBuffer[6]) && TryReadByte(out _dataBuffer[7]))
+            {
+                result = BitConverter.ToDouble(_dataBuffer, 0);
+                return true;
+            }
+
+            result = default(double);
+            return false;
         }
     }
 }


### PR DESCRIPTION
E.g., network streams might not support this.

Fixes #34.