### PR TITLE
refactor `DxfFile.Load()` to allow tests to directly verify `DxfCodePair.Offset` values

### DIFF
--- a/src/IxMilia.Dxf.Test/DxfReaderWriterTests.cs
+++ b/src/IxMilia.Dxf.Test/DxfReaderWriterTests.cs
@@ -150,6 +150,73 @@ EOF
         }
 
         [Fact]
+        public void ReadAsciiDxfCodePairOffsetTest()
+        {
+            using (var ms = new MemoryStream())
+            using (var writer = new StreamWriter(ms))
+            {
+                writer.WriteLine(@"
+  0
+SECTION
+  2
+ENTITIES
+  0
+LINE
+ 10
+1
+ 20
+2
+ 30
+3
+ 11
+4
+ 21
+5
+ 31
+6
+  0
+ENDSEC
+  0
+EOF
+".Trim());
+                writer.Flush();
+                ms.Seek(0, SeekOrigin.Begin);
+                using (var binaryReader = new BinaryReader(ms))
+                {
+                    int readBytes;
+                    var firstLine = DxfFile.GetFirstLine(binaryReader, out readBytes);
+                    var dxfReader = DxfFile.GetCodePairReader(firstLine, readBytes, binaryReader);
+                    var codePairs = dxfReader.GetCodePairs().ToList();
+
+                    // verify code pair offsets correspond to line numbers
+                    Assert.Equal(11, codePairs.Count);
+                    Assert.Equal(1, codePairs.First().Offset);
+                    Assert.Equal(21, codePairs.Last().Offset);
+                }
+            }
+        }
+
+        [Fact]
+        public void ReadBinaryDxfCodePairOffsetTest()
+        {
+            using (var fs = new FileStream("diamond-bin.dxf", FileMode.Open, FileAccess.Read))
+            {
+                using (var binaryReader = new BinaryReader(fs))
+                {
+                    int readBytes;
+                    var firstLine = DxfFile.GetFirstLine(binaryReader, out readBytes);
+                    var dxfReader = DxfFile.GetCodePairReader(firstLine, readBytes, binaryReader);
+                    var codePairs = dxfReader.GetCodePairs().ToList();
+
+                    // verify code pair offsets correspond to line numbers
+                    Assert.Equal(100, codePairs.Count);
+                    Assert.Equal(22, codePairs.First().Offset);
+                    Assert.Equal(805, codePairs.Last().Offset);
+                }
+            }
+        }
+
+        [Fact]
         public void WriteDxbTest()
         {
             // write file

--- a/src/IxMilia.Dxf/DxfBinaryReader.cs
+++ b/src/IxMilia.Dxf/DxfBinaryReader.cs
@@ -12,14 +12,18 @@ namespace IxMilia.Dxf
     {
         private BinaryReader _reader;
 
-        public DxfBinaryReader(BinaryReader reader)
+        public DxfBinaryReader(BinaryReader reader, int readBytes)
         {
             _reader = reader;
+            _totalBytesRead = readBytes;
 
             // swallow next two characters
-            var sub = reader.ReadChar();
+            var sub = reader.ReadByte();
+            _totalBytesRead++;
             Debug.Assert(sub == 0x1A);
-            var nul = reader.ReadChar();
+
+            var nul = reader.ReadByte();
+            _totalBytesRead++;
             Debug.Assert(nul == 0x00);
         }
 
@@ -145,7 +149,7 @@ namespace IxMilia.Dxf
         byte[] _miniBuffer = new byte[8];
         int _miniBufferStart = 0;
         int _miniBufferEnd = 0;
-        int _totalBytesRead = 22;
+        int _totalBytesRead = 0;
         byte[] _dataBuffer = new byte[8];
 
         private bool TryReadByte(out byte result)


### PR DESCRIPTION
Functionally this is a no-op, but it enables/adds unit tests to verify the correct `Offset` values.