### PR TITLE
properly parse `LWPOLYLINE` verticies, including optional values like `Bulge`.

### DIFF
--- a/src/IxMilia.Dxf.Test/DxfEntityTests.cs
+++ b/src/IxMilia.Dxf.Test/DxfEntityTests.cs
@@ -727,6 +727,52 @@ SEQEND
             Assert.Equal(new DxfVector(14, 15, 16), solid.ExtrusionDirection);
         }
 
+        [Fact]
+        public void ReadLwPolylineWithOptionalValuesTest()
+        {
+            var lwpolyline = (DxfLwPolyline)Entity("LWPOLYLINE", @"
+ 90
+4
+ 10
+2.0
+ 20
+0.0
+ 42
+0.7
+ 10
+1.0
+ 20
+2.5
+ 10
+-1.0
+ 20
+2.5
+ 42
+0.7
+ 10
+-2.0
+ 20
+0.0
+");
+            Assert.Equal(4, lwpolyline.Vertices.Count);
+
+            Assert.Equal(2.0, lwpolyline.Vertices[0].X);
+            Assert.Equal(0.0, lwpolyline.Vertices[0].Y);
+            Assert.Equal(0.7, lwpolyline.Vertices[0].Bulge);
+
+            Assert.Equal(1.0, lwpolyline.Vertices[1].X);
+            Assert.Equal(2.5, lwpolyline.Vertices[1].Y);
+            Assert.Equal(0.0, lwpolyline.Vertices[1].Bulge);
+
+            Assert.Equal(-1.0, lwpolyline.Vertices[2].X);
+            Assert.Equal(2.5, lwpolyline.Vertices[2].Y);
+            Assert.Equal(0.7, lwpolyline.Vertices[2].Bulge);
+
+            Assert.Equal(-2.0, lwpolyline.Vertices[3].X);
+            Assert.Equal(0.0, lwpolyline.Vertices[3].Y);
+            Assert.Equal(0.0, lwpolyline.Vertices[3].Bulge);
+        }
+
         #endregion
 
         #region Write default value tests
@@ -959,7 +1005,7 @@ AcDbTrace
 
         #endregion
 
-        #region Write specific value tests TODO
+        #region Write specific value tests
 
         [Fact]
         public void WriteLineTest()
@@ -1172,6 +1218,52 @@ AcDbEntity
 0
   0
 ENDSEC
+");
+        }
+
+        [Fact]
+        public void WriteLwPolylineWithOptionalValuesTest()
+        {
+            var lwpolyline = new DxfLwPolyline();
+            lwpolyline.Vertices.Add(new DxfLwPolylineVertex() { X = 2.0, Y = 0.0, Bulge = 0.7 });
+            lwpolyline.Vertices.Add(new DxfLwPolylineVertex() { X = 1.0, Y = 2.5 });
+            lwpolyline.Vertices.Add(new DxfLwPolylineVertex() { X = -1.0, Y = 2.5, Bulge = 0.7 });
+            lwpolyline.Vertices.Add(new DxfLwPolylineVertex() { X = -2.0, Y = 0.0 });
+            EnsureFileContainsEntity(lwpolyline, @"
+  0
+LWPOLYLINE
+  5
+A
+100
+AcDbEntity
+  8
+0
+100
+AcDbPolyline
+ 90
+4
+ 70
+0
+ 10
+2.0
+ 20
+0.0
+ 42
+0.7
+ 10
+1.0
+ 20
+2.5
+ 10
+-1.0
+ 20
+2.5
+ 42
+0.7
+ 10
+-2.0
+ 20
+0.0
 ");
         }
 

--- a/src/IxMilia.Dxf/DxfCommon.t4
+++ b/src/IxMilia.Dxf/DxfCommon.t4
@@ -132,6 +132,13 @@ bool AllowMultiples(XElement property)
     return att != null && bool.Parse(att.Value);
 }
 
+string SetterAccessibility(XElement property)
+{
+    if (AllowMultiples(property) && Accessibility(property) != "private")
+        return "private ";
+    return ProtectedSet(property) ? "protected " : "";
+}
+
 bool ProtectedSet(XElement property)
 {
     var att = property.Attribute("ProtectedSet");
@@ -181,12 +188,9 @@ IEnumerable<string> WriteValue(XElement spec, XElement entity)
         case "Foreach":
             var property = spec.Attribute("Property").Value;
             var lines = new List<string>();
-            lines.Add(string.Format("if ({0} != null)", property));
+            lines.Add(string.Format("foreach (var item in {0})", property));
             lines.Add("{");
-            lines.Add(string.Format("    foreach (var item in {0})", property));
-            lines.Add("    {");
-            lines.AddRange(spec.Elements().SelectMany(e => WriteValue(e, entity)).Select(l => "        " + l));
-            lines.Add("    }");
+            lines.AddRange(spec.Elements().SelectMany(e => WriteValue(e, entity)).Select(l => "    " + l));
             lines.Add("}");
             lines.Add("\n");
             return lines;
@@ -312,11 +316,6 @@ IEnumerable<string> GetPropertyWriteLines(XElement property)
 
     if (DisableWritingDefault(property))
         writePredicates.Add(string.Format("this.{0} != {1}", name, DefaultValue(property)));
-
-    if (codes == null && AllowMultiples(property))
-    {
-        writePredicates.Add(string.Format("this.{0} != null", name));
-    }
 
     string indentPrefix = string.Empty;
     if (writePredicates.Any())

--- a/src/IxMilia.Dxf/Entities/Dxf3DSolid.cs
+++ b/src/IxMilia.Dxf/Entities/Dxf3DSolid.cs
@@ -18,8 +18,8 @@ namespace IxMilia.Dxf.Entities
         protected override DxfAcadVersion MinVersion { get { return DxfAcadVersion.R13; } }
 
         public short FormatVersionNumber { get; set; }
-        public List<string> CustomData { get; set; }
-        public List<string> CustomData2 { get; set; }
+        public List<string> CustomData { get; private set; }
+        public List<string> CustomData2 { get; private set; }
         public uint HistoryObjectHandle { get; set; }
 
         public Dxf3DSolid()
@@ -41,16 +41,8 @@ namespace IxMilia.Dxf.Entities
             base.AddValuePairs(pairs, version, outputHandles);
             pairs.Add(new DxfCodePair(100, "AcDbModelerGeometry"));
             pairs.Add(new DxfCodePair(70, (this.FormatVersionNumber)));
-            if (this.CustomData != null)
-            {
-                pairs.AddRange(this.CustomData.Select(p => new DxfCodePair(1, p)));
-            }
-
-            if (this.CustomData2 != null)
-            {
-                pairs.AddRange(this.CustomData2.Select(p => new DxfCodePair(3, p)));
-            }
-
+            pairs.AddRange(this.CustomData.Select(p => new DxfCodePair(1, p)));
+            pairs.AddRange(this.CustomData2.Select(p => new DxfCodePair(3, p)));
             if (version >= DxfAcadVersion.R2007)
             {
                 pairs.Add(new DxfCodePair(100, "AcDb3dSolid"));

--- a/src/IxMilia.Dxf/Entities/DxfAttribute.cs
+++ b/src/IxMilia.Dxf/Entities/DxfAttribute.cs
@@ -38,7 +38,7 @@ namespace IxMilia.Dxf.Entities
         public DxfMTextFlag MTextFlag { get; set; }
         public bool IsReallyLocked { get; set; }
         private int SecondaryAttributeCount { get; set; }
-        public List<uint> SecondaryAttributeHandles { get; set; }
+        public List<uint> SecondaryAttributeHandles { get; private set; }
         public DxfPoint AlignmentPoint { get; set; }
         public double AnnotationScale { get; set; }
         public string XRecordTag { get; set; }
@@ -255,7 +255,7 @@ namespace IxMilia.Dxf.Entities
             {
                 pairs.Add(new DxfCodePair(70, (short?)SecondaryAttributeHandles?.Count ?? default(short)));
             }
-            if (version >= DxfAcadVersion.R2007 && this.SecondaryAttributeHandles != null)
+            if (version >= DxfAcadVersion.R2007)
             {
                 pairs.AddRange(this.SecondaryAttributeHandles.Select(p => new DxfCodePair(340, p)));
             }

--- a/src/IxMilia.Dxf/Entities/DxfAttributeDefinition.cs
+++ b/src/IxMilia.Dxf/Entities/DxfAttributeDefinition.cs
@@ -39,7 +39,7 @@ namespace IxMilia.Dxf.Entities
         public DxfMTextFlag MTextFlag { get; set; }
         public bool IsReallyLocked { get; set; }
         private int SecondaryAttributeCount { get; set; }
-        public List<uint> SecondaryAttributeHandles { get; set; }
+        public List<uint> SecondaryAttributeHandles { get; private set; }
         public DxfPoint AlignmentPoint { get; set; }
         public double AnnotationScale { get; set; }
         public string XRecordTag { get; set; }
@@ -262,7 +262,7 @@ namespace IxMilia.Dxf.Entities
             {
                 pairs.Add(new DxfCodePair(70, (short?)SecondaryAttributeHandles?.Count ?? default(short)));
             }
-            if (version >= DxfAcadVersion.R2007 && this.SecondaryAttributeHandles != null)
+            if (version >= DxfAcadVersion.R2007)
             {
                 pairs.AddRange(this.SecondaryAttributeHandles.Select(p => new DxfCodePair(340, p)));
             }

--- a/src/IxMilia.Dxf/Entities/DxfBody.cs
+++ b/src/IxMilia.Dxf/Entities/DxfBody.cs
@@ -18,8 +18,8 @@ namespace IxMilia.Dxf.Entities
         protected override DxfAcadVersion MinVersion { get { return DxfAcadVersion.R13; } }
 
         public short FormatVersionNumber { get; set; }
-        public List<string> CustomData { get; set; }
-        public List<string> CustomData2 { get; set; }
+        public List<string> CustomData { get; private set; }
+        public List<string> CustomData2 { get; private set; }
 
         public DxfBody()
             : base()
@@ -39,16 +39,8 @@ namespace IxMilia.Dxf.Entities
             base.AddValuePairs(pairs, version, outputHandles);
             pairs.Add(new DxfCodePair(100, "AcDbModelerGeometry"));
             pairs.Add(new DxfCodePair(70, (this.FormatVersionNumber)));
-            if (this.CustomData != null)
-            {
-                pairs.AddRange(this.CustomData.Select(p => new DxfCodePair(1, p)));
-            }
-
-            if (this.CustomData2 != null)
-            {
-                pairs.AddRange(this.CustomData2.Select(p => new DxfCodePair(3, p)));
-            }
-
+            pairs.AddRange(this.CustomData.Select(p => new DxfCodePair(1, p)));
+            pairs.AddRange(this.CustomData2.Select(p => new DxfCodePair(3, p)));
         }
 
         internal override bool TrySetPair(DxfCodePair pair)

--- a/src/IxMilia.Dxf/Entities/DxfEntityGenerated.cs
+++ b/src/IxMilia.Dxf/Entities/DxfEntityGenerated.cs
@@ -74,7 +74,7 @@ namespace IxMilia.Dxf.Entities
         public double LinetypeScale { get; set; }
         public bool IsVisible { get; set; }
         public int ImageByteCount { get; set; }
-        public List<string> PreviewImageData { get; set; }
+        public List<string> PreviewImageData { get; private set; }
         public int Color24Bit { get; set; }
         public string ColorName { get; set; }
         public int Transparency { get; set; }
@@ -287,7 +287,7 @@ namespace IxMilia.Dxf.Entities
                 pairs.Add(new DxfCodePair(92, (this.ImageByteCount)));
             }
 
-            if (version >= DxfAcadVersion.R2000 && this.PreviewImageData != null)
+            if (version >= DxfAcadVersion.R2000)
             {
                 pairs.AddRange(this.PreviewImageData.Select(p => new DxfCodePair(310, p)));
             }

--- a/src/IxMilia.Dxf/Entities/DxfEntityGenerated.tt
+++ b/src/IxMilia.Dxf/Entities/DxfEntityGenerated.tt
@@ -61,7 +61,7 @@ foreach (var property in GetProperties(baseEntity))
     if (AllowMultiples(property))
         typeString = string.Format("List<{0}>", typeString);
 #>
-        public <#= typeString #> <#= Name(property) #> { get; set; }
+        public <#= typeString #> <#= Name(property) #> { get; <#= SetterAccessibility(property) #>set; }
 <#
 } // foreach property
 #>
@@ -319,13 +319,12 @@ foreach (var entity in entities)
     foreach (var property in GetProperties(entity))
     {
         var propertyType = Type(property);
-        var getset = ProtectedSet(property) ? "{ get; protected set; }" : "{ get; set; }";
         if (AllowMultiples(property))
         {
             propertyType = string.Format("List<{0}>", propertyType);
         }
 #>
-        <#= Accessibility(property) #> <#= propertyType #> <#= Name(property) #> <#= getset #>
+        <#= Accessibility(property) #> <#= propertyType #> <#= Name(property) #> { get; <#= SetterAccessibility(property) #>set; }
 <#
     } // foreach property
 

--- a/src/IxMilia.Dxf/Entities/DxfEntitySection.cs
+++ b/src/IxMilia.Dxf/Entities/DxfEntitySection.cs
@@ -80,25 +80,19 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(63, DxfColor.GetRawValue(this.IndicatorColor)));
             pairs.Add(new DxfCodePair(411, (this.IndicatorColorName)));
             pairs.Add(new DxfCodePair(92, Vertices.Count));
-            if (Vertices != null)
+            foreach (var item in Vertices)
             {
-                foreach (var item in Vertices)
-                {
-                    pairs.Add(new DxfCodePair(11, item.X));
-                    pairs.Add(new DxfCodePair(21, item.Y));
-                    pairs.Add(new DxfCodePair(31, item.Z));
-                }
+                pairs.Add(new DxfCodePair(11, item.X));
+                pairs.Add(new DxfCodePair(21, item.Y));
+                pairs.Add(new DxfCodePair(31, item.Z));
             }
 
             pairs.Add(new DxfCodePair(93, BackLineVertices.Count));
-            if (BackLineVertices != null)
+            foreach (var item in BackLineVertices)
             {
-                foreach (var item in BackLineVertices)
-                {
-                    pairs.Add(new DxfCodePair(12, item.X));
-                    pairs.Add(new DxfCodePair(22, item.Y));
-                    pairs.Add(new DxfCodePair(32, item.Z));
-                }
+                pairs.Add(new DxfCodePair(12, item.X));
+                pairs.Add(new DxfCodePair(22, item.Y));
+                pairs.Add(new DxfCodePair(32, item.Z));
             }
 
             pairs.Add(new DxfCodePair(360, UIntHandle(this.GeometrySettingsHandle)));

--- a/src/IxMilia.Dxf/Entities/DxfImage.cs
+++ b/src/IxMilia.Dxf/Entities/DxfImage.cs
@@ -133,13 +133,10 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(360, (this.ImageDefReactorReference)));
             pairs.Add(new DxfCodePair(71, (short)(this.ClippingType)));
             pairs.Add(new DxfCodePair(91, ClippingVertices.Count));
-            if (ClippingVertices != null)
+            foreach (var item in ClippingVertices)
             {
-                foreach (var item in ClippingVertices)
-                {
-                    pairs.Add(new DxfCodePair(14, item.X));
-                    pairs.Add(new DxfCodePair(24, item.Y));
-                }
+                pairs.Add(new DxfCodePair(14, item.X));
+                pairs.Add(new DxfCodePair(24, item.Y));
             }
 
             if (version >= DxfAcadVersion.R2010)

--- a/src/IxMilia.Dxf/Entities/DxfLeader.cs
+++ b/src/IxMilia.Dxf/Entities/DxfLeader.cs
@@ -78,14 +78,11 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(40, (this.TextAnnotationHeight)));
             pairs.Add(new DxfCodePair(41, (this.TextAnnotationWidth)));
             pairs.Add(new DxfCodePair(76, (short)Vertices.Count));
-            if (Vertices != null)
+            foreach (var item in Vertices)
             {
-                foreach (var item in Vertices)
-                {
-                    pairs.Add(new DxfCodePair(10, item.X));
-                    pairs.Add(new DxfCodePair(20, item.Y));
-                    pairs.Add(new DxfCodePair(30, item.Z));
-                }
+                pairs.Add(new DxfCodePair(10, item.X));
+                pairs.Add(new DxfCodePair(20, item.Y));
+                pairs.Add(new DxfCodePair(30, item.Z));
             }
 
             if (this.OverrideColor != DxfColor.ByBlock)

--- a/src/IxMilia.Dxf/Entities/DxfLwPolyline.cs
+++ b/src/IxMilia.Dxf/Entities/DxfLwPolyline.cs
@@ -17,16 +17,10 @@ namespace IxMilia.Dxf.Entities
         public override DxfEntityType EntityType { get { return DxfEntityType.LwPolyline; } }
         protected override DxfAcadVersion MinVersion { get { return DxfAcadVersion.R14; } }
 
-        public int VertexCount { get; set; }
         public int Flags { get; set; }
         public double ConstantWidth { get; set; }
         public double Thickness { get; set; }
-        private List<double> VertexCoordinateX { get; set; }
-        private List<double> VertexCoordinateY { get; set; }
-        private List<int> VertexIdentifier { get; set; }
-        private List<double> StartingWidth { get; set; }
-        private List<double> EndingWidth { get; set; }
-        private List<double> Bulge { get; set; }
+        public List<DxfLwPolylineVertex> Vertices { get; private set; }
         public DxfVector ExtrusionDirection { get; set; }
 
         // Flags flags
@@ -61,16 +55,10 @@ namespace IxMilia.Dxf.Entities
         protected override void Initialize()
         {
             base.Initialize();
-            this.VertexCount = 0;
             this.Flags = 0;
             this.ConstantWidth = 0.0;
             this.Thickness = 0.0;
-            this.VertexCoordinateX = new List<double>();
-            this.VertexCoordinateY = new List<double>();
-            this.VertexIdentifier = new List<int>();
-            this.StartingWidth = new List<double>();
-            this.EndingWidth = new List<double>();
-            this.Bulge = new List<double>();
+            this.Vertices = new List<DxfLwPolylineVertex>();
             this.ExtrusionDirection = DxfVector.ZAxis;
         }
 
@@ -94,28 +82,25 @@ namespace IxMilia.Dxf.Entities
                 pairs.Add(new DxfCodePair(39, (this.Thickness)));
             }
 
-            if (Vertices != null)
+            foreach (var item in Vertices)
             {
-                foreach (var item in Vertices)
+                pairs.Add(new DxfCodePair(10, item.X));
+                pairs.Add(new DxfCodePair(20, item.Y));
+                if (version >= DxfAcadVersion.R2013)
                 {
-                    pairs.Add(new DxfCodePair(10, item.Location.X));
-                    pairs.Add(new DxfCodePair(20, item.Location.Y));
-                    if (version >= DxfAcadVersion.R2013)
-                    {
-                        pairs.Add(new DxfCodePair(91, item.Identifier));
-                    }
-                    if (item.StartingWidth != 0.0)
-                    {
-                        pairs.Add(new DxfCodePair(40, item.StartingWidth));
-                    }
-                    if (item.EndingWidth != 0.0)
-                    {
-                        pairs.Add(new DxfCodePair(41, item.EndingWidth));
-                    }
-                    if (item.Bulge != 0.0)
-                    {
-                        pairs.Add(new DxfCodePair(42, item.Bulge));
-                    }
+                    pairs.Add(new DxfCodePair(91, item.Identifier));
+                }
+                if (item.StartingWidth != 0.0)
+                {
+                    pairs.Add(new DxfCodePair(40, item.StartingWidth));
+                }
+                if (item.EndingWidth != 0.0)
+                {
+                    pairs.Add(new DxfCodePair(41, item.EndingWidth));
+                }
+                if (item.Bulge != 0.0)
+                {
+                    pairs.Add(new DxfCodePair(42, item.Bulge));
                 }
             }
 
@@ -126,56 +111,6 @@ namespace IxMilia.Dxf.Entities
                 pairs.Add(new DxfCodePair(230, ExtrusionDirection?.Z ?? default(double)));
             }
 
-        }
-
-        internal override bool TrySetPair(DxfCodePair pair)
-        {
-            switch (pair.Code)
-            {
-                case 10:
-                    this.VertexCoordinateX.Add((pair.DoubleValue));
-                    break;
-                case 20:
-                    this.VertexCoordinateY.Add((pair.DoubleValue));
-                    break;
-                case 39:
-                    this.Thickness = (pair.DoubleValue);
-                    break;
-                case 40:
-                    this.StartingWidth.Add((pair.DoubleValue));
-                    break;
-                case 41:
-                    this.EndingWidth.Add((pair.DoubleValue));
-                    break;
-                case 42:
-                    this.Bulge.Add((pair.DoubleValue));
-                    break;
-                case 43:
-                    this.ConstantWidth = (pair.DoubleValue);
-                    break;
-                case 70:
-                    this.Flags = (int)(pair.ShortValue);
-                    break;
-                case 90:
-                    this.VertexCount = (pair.IntegerValue);
-                    break;
-                case 91:
-                    this.VertexIdentifier.Add((pair.IntegerValue));
-                    break;
-                case 210:
-                    this.ExtrusionDirection.X = pair.DoubleValue;
-                    break;
-                case 220:
-                    this.ExtrusionDirection.Y = pair.DoubleValue;
-                    break;
-                case 230:
-                    this.ExtrusionDirection.Z = pair.DoubleValue;
-                    break;
-                default:
-                    return base.TrySetPair(pair);
-            }
-
-            return true;
         }
     }
 

--- a/src/IxMilia.Dxf/Entities/DxfLwPolylineVertex.cs
+++ b/src/IxMilia.Dxf/Entities/DxfLwPolylineVertex.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) IxMilia.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IxMilia.Dxf.Entities
+{
+    public class DxfLwPolylineVertex
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+        public int Identifier { get; set; }
+        public double StartingWidth { get; set; }
+        public double EndingWidth { get; set; }
+        public double Bulge { get; set; }
+    }
+}

--- a/src/IxMilia.Dxf/Entities/DxfMLine.cs
+++ b/src/IxMilia.Dxf/Entities/DxfMLine.cs
@@ -36,9 +36,9 @@ namespace IxMilia.Dxf.Entities
         private List<double> MiterDirectionY { get; set; }
         private List<double> MiterDirectionZ { get; set; }
         private int ParameterCount { get; set; }
-        public List<double> Parameters { get; set; }
+        public List<double> Parameters { get; private set; }
         private int AreaFillParameterCount { get; set; }
-        public List<double> AreaFillParameters { get; set; }
+        public List<double> AreaFillParameters { get; private set; }
 
         // Flags flags
 
@@ -139,48 +139,31 @@ namespace IxMilia.Dxf.Entities
                 pairs.Add(new DxfCodePair(230, Normal?.Z ?? default(double)));
             }
 
-            if (Vertices != null)
+            foreach (var item in Vertices)
             {
-                foreach (var item in Vertices)
-                {
-                    pairs.Add(new DxfCodePair(10, item.X));
-                    pairs.Add(new DxfCodePair(20, item.Y));
-                    pairs.Add(new DxfCodePair(30, item.Z));
-                }
+                pairs.Add(new DxfCodePair(10, item.X));
+                pairs.Add(new DxfCodePair(20, item.Y));
+                pairs.Add(new DxfCodePair(30, item.Z));
             }
 
-            if (SegmentDirections != null)
+            foreach (var item in SegmentDirections)
             {
-                foreach (var item in SegmentDirections)
-                {
-                    pairs.Add(new DxfCodePair(11, item.X));
-                    pairs.Add(new DxfCodePair(21, item.Y));
-                    pairs.Add(new DxfCodePair(31, item.Z));
-                }
+                pairs.Add(new DxfCodePair(11, item.X));
+                pairs.Add(new DxfCodePair(21, item.Y));
+                pairs.Add(new DxfCodePair(31, item.Z));
             }
 
-            if (MiterDirections != null)
+            foreach (var item in MiterDirections)
             {
-                foreach (var item in MiterDirections)
-                {
-                    pairs.Add(new DxfCodePair(12, item.X));
-                    pairs.Add(new DxfCodePair(22, item.Y));
-                    pairs.Add(new DxfCodePair(32, item.Z));
-                }
+                pairs.Add(new DxfCodePair(12, item.X));
+                pairs.Add(new DxfCodePair(22, item.Y));
+                pairs.Add(new DxfCodePair(32, item.Z));
             }
 
             pairs.Add(new DxfCodePair(74, (short?)Parameters?.Count ?? default(short)));
-            if (this.Parameters != null)
-            {
-                pairs.AddRange(this.Parameters.Select(p => new DxfCodePair(41, p)));
-            }
-
+            pairs.AddRange(this.Parameters.Select(p => new DxfCodePair(41, p)));
             pairs.Add(new DxfCodePair(75, (short?)AreaFillParameters?.Count ?? default(short)));
-            if (this.AreaFillParameters != null)
-            {
-                pairs.AddRange(this.AreaFillParameters.Select(p => new DxfCodePair(42, p)));
-            }
-
+            pairs.AddRange(this.AreaFillParameters.Select(p => new DxfCodePair(42, p)));
         }
 
         internal override bool TrySetPair(DxfCodePair pair)

--- a/src/IxMilia.Dxf/Entities/DxfMText.cs
+++ b/src/IxMilia.Dxf/Entities/DxfMText.cs
@@ -22,7 +22,7 @@ namespace IxMilia.Dxf.Entities
         public double ReferenceRectangleWidth { get; set; }
         public DxfAttachmentPoint AttachmentPoint { get; set; }
         public DxfDrawingDirection DrawingDirection { get; set; }
-        public List<string> ExtendedText { get; set; }
+        public List<string> ExtendedText { get; private set; }
         public string Text { get; set; }
         public string TextStyleName { get; set; }
         public DxfVector ExtrusionDirection { get; set; }
@@ -44,7 +44,7 @@ namespace IxMilia.Dxf.Entities
         public bool IsColumnAutoHeight { get; set; }
         public double ColumnWidth { get; set; }
         public double ColumnGutter { get; set; }
-        public List<double> ColumnHeights { get; set; }
+        public List<double> ColumnHeights { get; private set; }
         public DxfXData XData { get { return XDataProtected; } set { XDataProtected = value; } }
 
         public DxfMText()
@@ -96,11 +96,7 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(41, (this.ReferenceRectangleWidth)));
             pairs.Add(new DxfCodePair(71, (short)(this.AttachmentPoint)));
             pairs.Add(new DxfCodePair(72, (short)(this.DrawingDirection)));
-            if (this.ExtendedText != null)
-            {
-                pairs.AddRange(this.ExtendedText.Select(p => new DxfCodePair(3, p)));
-            }
-
+            pairs.AddRange(this.ExtendedText.Select(p => new DxfCodePair(3, p)));
             pairs.Add(new DxfCodePair(1, (this.Text)));
             if (this.TextStyleName != "STANDARD")
             {
@@ -139,11 +135,7 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(48, (this.ColumnWidth)));
             pairs.Add(new DxfCodePair(49, (this.ColumnGutter)));
             pairs.Add(new DxfCodePair(50, ColumnHeights?.Count ?? default(double)));
-            if (this.ColumnHeights != null)
-            {
-                pairs.AddRange(this.ColumnHeights.Select(p => new DxfCodePair(50, p)));
-            }
-
+            pairs.AddRange(this.ColumnHeights.Select(p => new DxfCodePair(50, p)));
             if (XData != null)
             {
                 XData.AddValuePairs(pairs, version, outputHandles);

--- a/src/IxMilia.Dxf/Entities/DxfOle2Frame.cs
+++ b/src/IxMilia.Dxf/Entities/DxfOle2Frame.cs
@@ -24,7 +24,7 @@ namespace IxMilia.Dxf.Entities
         public DxfOleObjectType ObjectType { get; set; }
         public DxfTileModeDescriptor TileMode { get; set; }
         public int BinaryDataLength { get; set; }
-        public List<string> BinaryDataStrings { get; set; }
+        public List<string> BinaryDataStrings { get; private set; }
 
         public DxfOle2Frame()
             : base()
@@ -59,12 +59,9 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(71, (short)(this.ObjectType)));
             pairs.Add(new DxfCodePair(72, (short)(this.TileMode)));
             pairs.Add(new DxfCodePair(90, (this.BinaryDataLength)));
-            if (BinaryDataStrings != null)
+            foreach (var item in BinaryDataStrings)
             {
-                foreach (var item in BinaryDataStrings)
-                {
-                    pairs.Add(new DxfCodePair(310, "item"));
-                }
+                pairs.Add(new DxfCodePair(310, "item"));
             }
 
             pairs.Add(new DxfCodePair(1, "OLE"));

--- a/src/IxMilia.Dxf/Entities/DxfOleFrame.cs
+++ b/src/IxMilia.Dxf/Entities/DxfOleFrame.cs
@@ -19,7 +19,7 @@ namespace IxMilia.Dxf.Entities
 
         public int VersionNumber { get; set; }
         public int BinaryDataLength { get; set; }
-        public List<string> BinaryDataStrings { get; set; }
+        public List<string> BinaryDataStrings { get; private set; }
 
         public DxfOleFrame()
             : base()
@@ -40,12 +40,9 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(100, "AcDbOleFrame"));
             pairs.Add(new DxfCodePair(70, (short)(this.VersionNumber)));
             pairs.Add(new DxfCodePair(90, (this.BinaryDataLength)));
-            if (BinaryDataStrings != null)
+            foreach (var item in BinaryDataStrings)
             {
-                foreach (var item in BinaryDataStrings)
-                {
-                    pairs.Add(new DxfCodePair(310, "item"));
-                }
+                pairs.Add(new DxfCodePair(310, "item"));
             }
 
             pairs.Add(new DxfCodePair(1, "OLE"));

--- a/src/IxMilia.Dxf/Entities/DxfProxyEntity.cs
+++ b/src/IxMilia.Dxf/Entities/DxfProxyEntity.cs
@@ -20,13 +20,13 @@ namespace IxMilia.Dxf.Entities
         public int ProxyEntityClassId { get; set; }
         public int ApplicationEntityClassId { get; set; }
         public int GraphicsDataSize { get; set; }
-        public List<string> GraphicsDataString { get; set; }
+        public List<string> GraphicsDataString { get; private set; }
         public int EntityDataSize { get; set; }
-        public List<string> EntityDataString { get; set; }
-        public List<string> ObjectID1 { get; set; }
-        public List<string> ObjectID2 { get; set; }
-        public List<string> ObjectID3 { get; set; }
-        public List<string> ObjectID4 { get; set; }
+        public List<string> EntityDataString { get; private set; }
+        public List<string> ObjectID1 { get; private set; }
+        public List<string> ObjectID2 { get; private set; }
+        public List<string> ObjectID3 { get; private set; }
+        public List<string> ObjectID4 { get; private set; }
         public int Terminator { get; set; }
         private uint ObjectDrawingFormat { get; set; }
         public bool OriginalDataFormatIsDxf { get; set; }
@@ -61,37 +61,13 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(90, (this.ProxyEntityClassId)));
             pairs.Add(new DxfCodePair(91, (this.ApplicationEntityClassId)));
             pairs.Add(new DxfCodePair(92, (this.GraphicsDataSize)));
-            if (this.GraphicsDataString != null)
-            {
-                pairs.AddRange(this.GraphicsDataString.Select(p => new DxfCodePair(310, p)));
-            }
-
+            pairs.AddRange(this.GraphicsDataString.Select(p => new DxfCodePair(310, p)));
             pairs.Add(new DxfCodePair(93, (this.EntityDataSize)));
-            if (this.EntityDataString != null)
-            {
-                pairs.AddRange(this.EntityDataString.Select(p => new DxfCodePair(310, p)));
-            }
-
-            if (this.ObjectID1 != null)
-            {
-                pairs.AddRange(this.ObjectID1.Select(p => new DxfCodePair(330, p)));
-            }
-
-            if (this.ObjectID2 != null)
-            {
-                pairs.AddRange(this.ObjectID2.Select(p => new DxfCodePair(340, p)));
-            }
-
-            if (this.ObjectID3 != null)
-            {
-                pairs.AddRange(this.ObjectID3.Select(p => new DxfCodePair(350, p)));
-            }
-
-            if (this.ObjectID4 != null)
-            {
-                pairs.AddRange(this.ObjectID4.Select(p => new DxfCodePair(360, p)));
-            }
-
+            pairs.AddRange(this.EntityDataString.Select(p => new DxfCodePair(310, p)));
+            pairs.AddRange(this.ObjectID1.Select(p => new DxfCodePair(330, p)));
+            pairs.AddRange(this.ObjectID2.Select(p => new DxfCodePair(340, p)));
+            pairs.AddRange(this.ObjectID3.Select(p => new DxfCodePair(350, p)));
+            pairs.AddRange(this.ObjectID4.Select(p => new DxfCodePair(360, p)));
             pairs.Add(new DxfCodePair(94, (this.Terminator)));
             if (version >= DxfAcadVersion.R2000)
             {

--- a/src/IxMilia.Dxf/Entities/DxfRegion.cs
+++ b/src/IxMilia.Dxf/Entities/DxfRegion.cs
@@ -18,8 +18,8 @@ namespace IxMilia.Dxf.Entities
         protected override DxfAcadVersion MinVersion { get { return DxfAcadVersion.R13; } }
 
         public short FormatVersionNumber { get; set; }
-        public List<string> CustomData { get; set; }
-        public List<string> CustomData2 { get; set; }
+        public List<string> CustomData { get; private set; }
+        public List<string> CustomData2 { get; private set; }
 
         public DxfRegion()
             : base()
@@ -39,16 +39,8 @@ namespace IxMilia.Dxf.Entities
             base.AddValuePairs(pairs, version, outputHandles);
             pairs.Add(new DxfCodePair(100, "AcDbModelerGeometry"));
             pairs.Add(new DxfCodePair(70, (this.FormatVersionNumber)));
-            if (this.CustomData != null)
-            {
-                pairs.AddRange(this.CustomData.Select(p => new DxfCodePair(1, p)));
-            }
-
-            if (this.CustomData2 != null)
-            {
-                pairs.AddRange(this.CustomData2.Select(p => new DxfCodePair(3, p)));
-            }
-
+            pairs.AddRange(this.CustomData.Select(p => new DxfCodePair(1, p)));
+            pairs.AddRange(this.CustomData2.Select(p => new DxfCodePair(3, p)));
         }
 
         internal override bool TrySetPair(DxfCodePair pair)

--- a/src/IxMilia.Dxf/Entities/DxfSpline.cs
+++ b/src/IxMilia.Dxf/Entities/DxfSpline.cs
@@ -28,7 +28,7 @@ namespace IxMilia.Dxf.Entities
         public double FitTolerance { get; set; }
         public DxfPoint StartTangent { get; set; }
         public DxfPoint EndTangent { get; set; }
-        public List<double> KnotValues { get; set; }
+        public List<double> KnotValues { get; private set; }
         public double Weight { get; set; }
         private List<double> ControlPointX { get; set; }
         private List<double> ControlPointY { get; set; }
@@ -155,34 +155,24 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(13, EndTangent?.X ?? default(double)));
             pairs.Add(new DxfCodePair(23, EndTangent?.Y ?? default(double)));
             pairs.Add(new DxfCodePair(33, EndTangent?.Z ?? default(double)));
-            if (this.KnotValues != null)
-            {
-                pairs.AddRange(this.KnotValues.Select(p => new DxfCodePair(40, p)));
-            }
-
+            pairs.AddRange(this.KnotValues.Select(p => new DxfCodePair(40, p)));
             if (this.Weight != 1.0)
             {
                 pairs.Add(new DxfCodePair(41, (this.Weight)));
             }
 
-            if (ControlPoints != null)
+            foreach (var item in ControlPoints)
             {
-                foreach (var item in ControlPoints)
-                {
-                    pairs.Add(new DxfCodePair(10, item.X));
-                    pairs.Add(new DxfCodePair(20, item.Y));
-                    pairs.Add(new DxfCodePair(30, item.Z));
-                }
+                pairs.Add(new DxfCodePair(10, item.X));
+                pairs.Add(new DxfCodePair(20, item.Y));
+                pairs.Add(new DxfCodePair(30, item.Z));
             }
 
-            if (FitPoints != null)
+            foreach (var item in FitPoints)
             {
-                foreach (var item in FitPoints)
-                {
-                    pairs.Add(new DxfCodePair(11, item.X));
-                    pairs.Add(new DxfCodePair(21, item.Y));
-                    pairs.Add(new DxfCodePair(31, item.Z));
-                }
+                pairs.Add(new DxfCodePair(11, item.X));
+                pairs.Add(new DxfCodePair(21, item.Y));
+                pairs.Add(new DxfCodePair(31, item.Z));
             }
 
         }

--- a/src/IxMilia.Dxf/Entities/DxfUnderlay.cs
+++ b/src/IxMilia.Dxf/Entities/DxfUnderlay.cs
@@ -144,13 +144,10 @@ namespace IxMilia.Dxf.Entities
             pairs.Add(new DxfCodePair(280, (short)(this.Flags)));
             pairs.Add(new DxfCodePair(281, (this.Contrast)));
             pairs.Add(new DxfCodePair(282, (this.Fade)));
-            if (BoundaryPoints != null)
+            foreach (var item in BoundaryPoints)
             {
-                foreach (var item in BoundaryPoints)
-                {
-                    pairs.Add(new DxfCodePair(11, item.X));
-                    pairs.Add(new DxfCodePair(12, item.Y));
-                }
+                pairs.Add(new DxfCodePair(11, item.X));
+                pairs.Add(new DxfCodePair(12, item.Y));
             }
 
         }

--- a/src/IxMilia.Dxf/Entities/EntitiesSpec.xml
+++ b/src/IxMilia.Dxf/Entities/EntitiesSpec.xml
@@ -604,20 +604,14 @@
   LWPOLYLINE
   
   -->
-  <Entity Name="DxfLwPolyline" EntityType="LwPolyline" SubclassMarker="AcDbPolyline" TypeString="LWPOLYLINE" MinVersion="R14">
-    <Property Name="VertexCount" Code="90" Type="int" DefaultValue="0" />
+  <Entity Name="DxfLwPolyline" EntityType="LwPolyline" SubclassMarker="AcDbPolyline" TypeString="LWPOLYLINE" MinVersion="R14" GenerateReaderFunction="false">
     <Property Name="Flags" Code="70" Type="int" DefaultValue="0" ReadConverter="(int)" WriteConverter="(short)">
       <Flag Name="IsClosed" Mask="1" />
       <Flag Name="IsPLineGen" Mask="128" />
     </Property>
     <Property Name="ConstantWidth" Code="43" Type="double" DefaultValue="0.0" DisableWritingDefault="true" />
     <Property Name="Thickness" Code="39" Type="double" DefaultValue="0.0" DisableWritingDefault="true" />
-    <Property Name="VertexCoordinateX" Code="10" Type="double" DefaultValue="" Accessibility="private" AllowMultiples="true" />
-    <Property Name="VertexCoordinateY" Code="20" Type="double" DefaultValue="" Accessibility="private" AllowMultiples="true" />
-    <Property Name="VertexIdentifier" Code="91" Type="int" DefaultValue="0" Accessibility="private" AllowMultiples="true" />
-    <Property Name="StartingWidth" Code="40" Type="double" DefaultValue="" Accessibility="private" AllowMultiples="true" DisableWritingDefault="true" />
-    <Property Name="EndingWidth" Code="41" Type="double" DefaultValue="" Accessibility="private" AllowMultiples="true" DisableWritingDefault="true" />
-    <Property Name="Bulge" Code="42" Type="double" DefaultValue="" Accessibility="private" AllowMultiples="true" DisableWritingDefault="true" />
+    <Property Name="Vertices" Code="10" Type="DxfLwPolylineVertex" DefaultValue="null" AllowMultiples="true" />
     <Property Name="ExtrusionDirection" Code="210" Type="DxfVector" DefaultValue="DxfVector.ZAxis" DisableWritingDefault="true" CodeOverrides="210,220,230" />
     <WriteOrder>
       <WriteSpecificValue Code="100" Value="AcDbPolyline" />
@@ -627,8 +621,8 @@
       <WriteSpecificValue Code="38" Value="Elevation" DontWriteIfValueIs="0.0" />
       <WriteProperty Property="Thickness" />
       <Foreach Property="Vertices">
-        <WriteSpecificValue Code="10" Value="item.Location.X" />
-        <WriteSpecificValue Code="20" Value="item.Location.Y" />
+        <WriteSpecificValue Code="10" Value="item.X" />
+        <WriteSpecificValue Code="20" Value="item.Y" />
         <WriteSpecificValue Code="91" Value="item.Identifier" MinVersion="R2013" />
         <WriteSpecificValue Code="40" Value="item.StartingWidth" DontWriteIfValueIs="0.0" />
         <WriteSpecificValue Code="41" Value="item.EndingWidth" DontWriteIfValueIs="0.0" />

--- a/src/IxMilia.Dxf/IxMilia.Dxf.csproj
+++ b/src/IxMilia.Dxf/IxMilia.Dxf.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Entities\DxfLwPolyline.cs">
       <DependentUpon>DxfEntityGenerated.tt</DependentUpon>
     </Compile>
+    <Compile Include="Entities\DxfLwPolylineVertex.cs" />
     <Compile Include="Entities\DxfMLeaderStyle.cs">
       <DependentUpon>DxfEntityGenerated.tt</DependentUpon>
     </Compile>


### PR DESCRIPTION
Also make setters for entity properties that allow multiple values to `private`.  Since we already guarantee that these won't be `null`, we can also remove some `null` checks.

Fixes #46.

FYI @nzain