### PR TITLE
fix reading XRECORD objects with no duplicate-handling flag

### DIFF
--- a/src/IxMilia.Dxf.Test/DxfObjectTests.cs
+++ b/src/IxMilia.Dxf.Test/DxfObjectTests.cs
@@ -1614,7 +1614,7 @@ two
         }
 
         [Fact]
-        public void ReadXRecordWithMultipleXDataTest()
+        public void ReadXRecordWithMultipleXDataTest1()
         {
             var xrecord = (DxfXRecordObject)GenObject("XRECORD", @"
 102
@@ -1676,6 +1676,49 @@ VTR_0.000_0.000_1.000_1.000_CONTRAST
             Assert.Equal(14, xrecord.DataPairs.Count);
             Assert.Equal(102, xrecord.DataPairs[0].Code);
             Assert.Equal("VTR_0.000_0.000_1.000_1.000_VISUALSTYLE", xrecord.DataPairs[0].StringValue);
+        }
+
+        [Fact]
+        public void ReadXRecordWithMultipleXDataTest2()
+        {
+            // reads an XRECORD object that hasn't specified it's 280 code pair for duplicate record handling
+            var xrecord = (DxfXRecordObject)GenObject("XRECORD", @"
+100
+AcDbXrecord
+102
+VTR_0.000_0.000_1.000_1.000_VISUALSTYLE
+340
+195
+102
+VTR_0.000_0.000_1.000_1.000_GRIDDISPLAY
+ 70
+     3
+102
+VTR_0.000_0.000_1.000_1.000_GRIDMAJOR
+ 70
+     5
+102
+VTR_0.000_0.000_1.000_1.000_DEFAULTLIGHTING
+280
+     1
+102
+VTR_0.000_0.000_1.000_1.000_DEFAULTLIGHTINGTYPE
+ 70
+     1
+102
+VTR_0.000_0.000_1.000_1.000_BRIGHTNESS
+141
+0.0
+102
+VTR_0.000_0.000_1.000_1.000_CONTRAST
+142
+0.0
+");
+            Assert.Equal(0, xrecord.ExtensionDataGroups.Count);
+            Assert.Equal(14, xrecord.DataPairs.Count);
+            Assert.Equal(102, xrecord.DataPairs[6].Code);
+            Assert.Equal("VTR_0.000_0.000_1.000_1.000_DEFAULTLIGHTING", xrecord.DataPairs[6].StringValue);
+            Assert.Equal(1, xrecord.DataPairs[7].ShortValue);
         }
 
         [Fact]

--- a/src/IxMilia.Dxf/Objects/DxfXRecordObject.cs
+++ b/src/IxMilia.Dxf/Objects/DxfXRecordObject.cs
@@ -19,7 +19,6 @@ namespace IxMilia.Dxf.Objects
 
         internal override DxfObject PopulateFromBuffer(DxfCodePairBufferReader buffer)
         {
-            bool readDuplicateFlag = false;
             bool readingData = false;
             while (buffer.ItemsRemain)
             {
@@ -35,6 +34,14 @@ namespace IxMilia.Dxf.Objects
                 }
                 else
                 {
+                    if (pair.Code == 280)
+                    {
+                        DuplicateRecordHandling = (DxfDictionaryDuplicateRecordHandling)pair.ShortValue;
+                        buffer.Advance();
+                        readingData = true;
+                        continue;
+                    }
+
                     if (base.TrySetPair(pair))
                     {
                         buffer.Advance();
@@ -52,13 +59,6 @@ namespace IxMilia.Dxf.Objects
                         buffer.Advance();
                         continue;
                     }
-
-                    if (pair.Code == 280 && !readDuplicateFlag)
-                    {
-                        DuplicateRecordHandling = (DxfDictionaryDuplicateRecordHandling)pair.ShortValue;
-                        readDuplicateFlag = true;
-                        readingData = true;
-                    }
                     else if (pair.Code == 5 || pair.Code == 105)
                     {
                         // these codes aren't allowed here
@@ -67,6 +67,7 @@ namespace IxMilia.Dxf.Objects
                     else
                     {
                         DataPairs.Add(pair);
+                        readingData = true;
                     }
                 }
 


### PR DESCRIPTION
When reading and `XRECORD` object, the only possibilities following the `100/AcDbXrecord` code pair are either a code `280` which indicates the duplicate record handling flag, or a code `102` which is just regular data.

This moves the code `280` handler higher in the loop to account for the case where a code `102` immediately follows the `100/AcDbXrecord` pair which means any subsequent code `280` must belong to the data section and not the duplicate record handling flag.

Fixes #61

FYI @AleksandarDev