### PR TITLE
Fix reading point triple real

### DIFF
--- a/src/IxMilia.Dxf.Test/DxfReaderWriterTests.cs
+++ b/src/IxMilia.Dxf.Test/DxfReaderWriterTests.cs
@@ -687,6 +687,102 @@ ENDTAB
         }
 
         [Fact]
+        public void ReadRealTriple()
+        {
+            var file = Section("TABLES", @"
+  0
+TABLE
+  2
+BLOCK_RECORD
+  5
+2
+330
+0
+100
+AcDbSymbolTable
+ 70
+0
+  0
+BLOCK_RECORD
+  5
+A
+330
+0
+100
+AcDbSymbolTableRecord
+100
+AcDbBlockTableRecord
+  2
+<name>
+340
+A1
+310
+010203040506070809
+310
+010203040506070809
+1001
+ACAD
+1000
+DesignCenter Data
+1002
+{
+1070
+0
+1070
+1
+1070
+2
+1010
+3.1
+1020
+4.2
+1030
+5.3
+1002
+}
+  0
+ENDTAB
+");
+            var blockRecord = file.BlockRecords.Single();
+            Assert.Equal("<name>", blockRecord.Name);
+            Assert.Equal(0xA1u, blockRecord.LayoutHandle);
+
+            var xdata = blockRecord.XData;
+            Assert.Equal("ACAD", xdata.ApplicationName);
+            Assert.Equal(2, xdata.Items.Count);
+
+            Assert.Equal(DxfXDataType.String, xdata.Items[0].Type);
+            Assert.Equal("DesignCenter Data", ((DxfXDataString)xdata.Items[0]).Value);
+
+            var group = (DxfXDataControlGroup)xdata.Items[1];
+            Assert.Equal(4, group.Items.Count);
+
+            Assert.Equal(DxfXDataType.Integer, group.Items[0].Type);
+            Assert.Equal((short)0, ((DxfXDataInteger)group.Items[0]).Value);
+
+            Assert.Equal(DxfXDataType.Integer, group.Items[1].Type);
+            Assert.Equal((short)1, ((DxfXDataInteger)group.Items[1]).Value);
+
+            Assert.Equal(DxfXDataType.Integer, group.Items[2].Type);
+            Assert.Equal((short)2, ((DxfXDataInteger)group.Items[2]).Value);
+
+            Assert.Equal(DxfXDataType.RealTriple, group.Items[3].Type);
+            Assert.Equal(3.1, ((DxfXData3Reals)group.Items[3]).Value.X);
+
+            Assert.Equal(DxfXDataType.RealTriple, group.Items[3].Type);
+            Assert.Equal(4.2, ((DxfXData3Reals)group.Items[3]).Value.Y);
+
+            Assert.Equal(DxfXDataType.RealTriple, group.Items[3].Type);
+            Assert.Equal(5.3, ((DxfXData3Reals)group.Items[3]).Value.Z);
+
+            AssertArrayEqual(new byte[]
+            {
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09
+            }, blockRecord.BitmapData);
+        }
+
+        [Fact]
         public void WriteVersionSpecificBlockRecordTest_R2000()
         {
             var file = new DxfFile();

--- a/src/IxMilia.Dxf/DxfXData.cs
+++ b/src/IxMilia.Dxf/DxfXData.cs
@@ -168,13 +168,13 @@ namespace IxMilia.Dxf
                 case DxfXDataType.Handle:
                     return new DxfXDataHandle(DxfCommonConverters.UIntHandle(pair.StringValue));
                 case DxfXDataType.RealTriple:
-                    return new DxfXData3Reals(ReadPoint(buffer, pair.Code));
+                    return new DxfXData3Reals(ReadPoint(pair, buffer, pair.Code));
                 case DxfXDataType.WorldSpacePosition:
-                    return new DxfXDataWorldSpacePosition(ReadPoint(buffer, pair.Code));
+                    return new DxfXDataWorldSpacePosition(ReadPoint(pair, buffer, pair.Code));
                 case DxfXDataType.WorldSpaceDisplacement:
-                    return new DxfXDataWorldSpaceDisplacement(ReadPoint(buffer, pair.Code));
+                    return new DxfXDataWorldSpaceDisplacement(ReadPoint(pair, buffer, pair.Code));
                 case DxfXDataType.WorldDirection:
-                    return new DxfXDataWorldDirection(ReadPoint(buffer, pair.Code));
+                    return new DxfXDataWorldDirection(ReadPoint(pair, buffer, pair.Code));
                 case DxfXDataType.Real:
                     return new DxfXDataReal(pair.DoubleValue);
                 case DxfXDataType.Distance:
@@ -190,14 +190,12 @@ namespace IxMilia.Dxf
             }
         }
 
-        private static DxfPoint ReadPoint(DxfCodePairBufferReader buffer, int expectedFirstCode)
+        private static DxfPoint ReadPoint(DxfCodePair xCoord, DxfCodePairBufferReader buffer, int expectedFirstCode)
         {
             // first value
-            Debug.Assert(buffer.ItemsRemain);
-            var pair = buffer.Peek();
+            var pair = xCoord;
             Debug.Assert(pair.Code == expectedFirstCode);
             var x = pair.DoubleValue;
-            buffer.Advance();
 
             // second value
             Debug.Assert(buffer.ItemsRemain);


### PR DESCRIPTION
There is an issue with reading RealTriple.
`internal static DxfXDataItem FromBuffer(DxfCodePairBufferReader buffer)` method does `buffer.Advance()` before reading 3 real values, then the `Advance()` method is called 3 times in `private static DxfPoint ReadPoint(DxfCodePair xCoord, DxfCodePairBufferReader buffer, int expectedFirstCode)`. It may cause 2 issues: either wrong data is read or casting string to double occurs.
For example:
```
(...)
1010
3.1
1020
4.2
1030
5.3
1002
}
```

`1010` starts real triple, but as buffer is advanced the`ReadPoint` method tries to set:
```
X=4.2
Y=5.3
Z=}
```

The fix in this pull request fixes the issue by passing to `ReadPoint` method already read `DxfCodePair` from buffer and only 2 items are read inside `ReadPoint` from buffer.

I've splitted the fix into 2 commits. Firs commit contains new test for reading RealTriple (it fails, as the production code is not fixed here) while the second introduces the fix.