### PR TITLE
Support and build for net35

### DIFF
--- a/src/IxMilia.Dxf.Generator/TableGenerator.cs
+++ b/src/IxMilia.Dxf.Generator/TableGenerator.cs
@@ -58,7 +58,11 @@ namespace IxMilia.Dxf.Generator
                 AppendLine();
                 AppendLine("protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()");
                 AppendLine("{");
+                AppendLine("#if NET35");
+                AppendLine("    return Items.Cast<DxfSymbolTableFlags>();");
+                AppendLine("#else");
                 AppendLine("    return Items;");
+                this.AppendLine("#endif");
                 AppendLine("}");
 
                 //

--- a/src/IxMilia.Dxf.Generator/TableGenerator.cs
+++ b/src/IxMilia.Dxf.Generator/TableGenerator.cs
@@ -58,11 +58,7 @@ namespace IxMilia.Dxf.Generator
                 AppendLine();
                 AppendLine("protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()");
                 AppendLine("{");
-                AppendLine("#if NET35");
                 AppendLine("    return Items.Cast<DxfSymbolTableFlags>();");
-                AppendLine("#else");
-                AppendLine("    return Items;");
-                this.AppendLine("#endif");
                 AppendLine("}");
 
                 //

--- a/src/IxMilia.Dxf/Compat.cs
+++ b/src/IxMilia.Dxf/Compat.cs
@@ -22,6 +22,7 @@ namespace IxMilia.Dxf
                     }
                 }
             }
+            
             return true;
 #else
             return string.IsNullOrWhiteSpace(value);
@@ -47,6 +48,7 @@ namespace IxMilia.Dxf
             {
                 return result;
             }
+
             return Guid.Empty;
 #endif
         }

--- a/src/IxMilia.Dxf/Compat.cs
+++ b/src/IxMilia.Dxf/Compat.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace IxMilia.Dxf
+{
+    /// <summary>Compatibility layer to support net35, but use modern APIs where possible.</summary>
+    internal static class Compat
+    {
+        /// <summary>Indicates where the given string is <c>null</c>, empty, or consists only of white-space characters.</summary>
+        /// <param name="value">The string to test.</param>
+        /// <returns>true if <c>null</c>, empty, or whitespace.</returns>
+        public static bool IsNullOrWhiteSpace(string value)
+        {
+#if NET35
+            if (value != null)
+            {
+                foreach (char c in value)
+                {
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+#else
+            return string.IsNullOrWhiteSpace(value);
+#endif
+        }
+
+        /// <summary>Converts the string representation to a <see cref="Guid" /> (success) or <see cref="Guid.Empty" />.</summary>
+        /// <param name="s">The string to parse.</param>
+        /// <returns>The guid.</returns>
+        public static Guid GuidString(string s)
+        {
+#if NET35
+            try
+            {
+                return new Guid(s);
+            }
+            catch
+            {
+                return Guid.Empty;
+            }
+#else
+            if (Guid.TryParse(s, out Guid result))
+            {
+                return result;
+            }
+            return Guid.Empty;
+#endif
+        }
+    }
+}

--- a/src/IxMilia.Dxf/DxfCommonConverters.cs
+++ b/src/IxMilia.Dxf/DxfCommonConverters.cs
@@ -38,12 +38,7 @@ namespace IxMilia.Dxf
 
         public static Guid GuidString(string s)
         {
-            if (Guid.TryParse(s, out var result))
-            {
-                return result;
-            }
-
-            return Guid.Empty;
+            return Compat.GuidString(s);
         }
 
         public static uint UIntHandle(string s)
@@ -169,7 +164,7 @@ namespace IxMilia.Dxf
 
         public static Func<string, string> DefaultIfNullOrEmpty(string defaultValue)
         {
-            return value => string.IsNullOrWhiteSpace(value) ? defaultValue : value;
+            return value => Compat.IsNullOrWhiteSpace(value) ? defaultValue : value;
         }
     }
 }

--- a/src/IxMilia.Dxf/DxfFile.cs
+++ b/src/IxMilia.Dxf/DxfFile.cs
@@ -439,13 +439,26 @@ namespace IxMilia.Dxf
 
         private void EnsureTableItems()
         {
+#if NET35
+            var existingDimStyles = GetExistingNames(DimensionStyles.Cast<DxfSymbolTableFlags>());
+            var existingLayers = GetExistingNames(Layers.Cast<DxfSymbolTableFlags>());
+            var existingLineTypes = GetExistingNames(LineTypes.Cast<DxfSymbolTableFlags>());
+            var existingStyles = GetExistingNames(Styles.Cast<DxfSymbolTableFlags>());
+            var existingViews = GetExistingNames(Views.Cast<DxfSymbolTableFlags>());
+            var existingUcs = GetExistingNames(UserCoordinateSystems.Cast<DxfSymbolTableFlags>());
+#else
             var existingDimStyles = GetExistingNames(DimensionStyles);
+            var existingLayers = GetExistingNames(Layers);
+            var existingLineTypes = GetExistingNames(LineTypes);
+            var existingStyles = GetExistingNames(Styles);
+            var existingViews = GetExistingNames(Views);
+            var existingUcs = GetExistingNames(UserCoordinateSystems);
+#endif      
             AddMissingDimensionStyles(existingDimStyles, new[] { Header.DimensionStyleName });
             AddMissingDimensionStyles(existingDimStyles, Entities.OfType<DxfDimensionBase>().Select(d => d.DimensionStyleName));
             AddMissingDimensionStyles(existingDimStyles, Entities.OfType<DxfLeader>().Select(d => d.DimensionStyleName));
             AddMissingDimensionStyles(existingDimStyles, Entities.OfType<DxfTolerance>().Select(d => d.DimensionStyleName));
 
-            var existingLayers = GetExistingNames(Layers);
             AddMissingLayers(existingLayers, new[] { Header.CurrentLayer });
             AddMissingLayers(existingLayers, Blocks.Select(b => b.Layer));
             AddMissingLayers(existingLayers, Blocks.SelectMany(b => b.Entities.Select(e => e.Layer)));
@@ -453,14 +466,12 @@ namespace IxMilia.Dxf
             AddMissingLayers(existingLayers, Objects.OfType<DxfLayerFilter>().SelectMany(l => l.LayerNames));
             AddMissingLayers(existingLayers, Objects.OfType<DxfLayerIndex>().SelectMany(l => l.LayerNames));
 
-            var existingLineTypes = GetExistingNames(LineTypes);
             AddMissingLineTypes(existingLineTypes, new[] { Header.CurrentEntityLineType, Header.DimensionLineType });
             AddMissingLineTypes(existingLineTypes, Layers.Select(l => l.LineTypeName));
             AddMissingLineTypes(existingLineTypes, Blocks.SelectMany(b => b.Entities.Select(e => e.LineTypeName)));
             AddMissingLineTypes(existingLineTypes, Entities.Select(e => e.LineTypeName));
             AddMissingLineTypes(existingLineTypes, Objects.OfType<DxfMLineStyle>().SelectMany(m => m.Elements.Select(e => e.LineType)));
 
-            var existingStyles = GetExistingNames(Styles);
             AddMissingStyles(existingStyles, Entities.OfType<DxfArcAlignedText>().Select(a => a.TextStyleName));
             AddMissingStyles(existingStyles, Entities.OfType<DxfAttribute>().Select(a => a.TextStyleName));
             AddMissingStyles(existingStyles, Entities.OfType<DxfAttributeDefinition>().Select(a => a.TextStyleName));
@@ -468,10 +479,8 @@ namespace IxMilia.Dxf
             AddMissingStyles(existingStyles, Entities.OfType<DxfText>().Select(t => t.TextStyleName));
             AddMissingStyles(existingStyles, Objects.OfType<DxfMLineStyle>().Select(m => m.StyleName));
 
-            var existingViews = GetExistingNames(Views);
             AddMissingViews(existingViews, Objects.OfType<DxfPlotSettings>().Select(p => p.PlotViewName));
 
-            var existingUcs = GetExistingNames(UserCoordinateSystems);
             AddMissingUcs(existingUcs, new[] {
                 Header.UCSDefinitionName,
                 Header.UCSName,

--- a/src/IxMilia.Dxf/DxfFile.cs
+++ b/src/IxMilia.Dxf/DxfFile.cs
@@ -439,48 +439,39 @@ namespace IxMilia.Dxf
 
         private void EnsureTableItems()
         {
-#if NET35
             var existingDimStyles = GetExistingNames(DimensionStyles.Cast<DxfSymbolTableFlags>());
-            var existingLayers = GetExistingNames(Layers.Cast<DxfSymbolTableFlags>());
-            var existingLineTypes = GetExistingNames(LineTypes.Cast<DxfSymbolTableFlags>());
-            var existingStyles = GetExistingNames(Styles.Cast<DxfSymbolTableFlags>());
-            var existingViews = GetExistingNames(Views.Cast<DxfSymbolTableFlags>());
-            var existingUcs = GetExistingNames(UserCoordinateSystems.Cast<DxfSymbolTableFlags>());
-#else
-            var existingDimStyles = GetExistingNames(DimensionStyles);
-            var existingLayers = GetExistingNames(Layers);
-            var existingLineTypes = GetExistingNames(LineTypes);
-            var existingStyles = GetExistingNames(Styles);
-            var existingViews = GetExistingNames(Views);
-            var existingUcs = GetExistingNames(UserCoordinateSystems);
-#endif      
             AddMissingDimensionStyles(existingDimStyles, new[] { Header.DimensionStyleName });
             AddMissingDimensionStyles(existingDimStyles, Entities.OfType<DxfDimensionBase>().Select(d => d.DimensionStyleName));
             AddMissingDimensionStyles(existingDimStyles, Entities.OfType<DxfLeader>().Select(d => d.DimensionStyleName));
             AddMissingDimensionStyles(existingDimStyles, Entities.OfType<DxfTolerance>().Select(d => d.DimensionStyleName));
-
+            
+            var existingLayers = GetExistingNames(Layers.Cast<DxfSymbolTableFlags>());
             AddMissingLayers(existingLayers, new[] { Header.CurrentLayer });
             AddMissingLayers(existingLayers, Blocks.Select(b => b.Layer));
             AddMissingLayers(existingLayers, Blocks.SelectMany(b => b.Entities.Select(e => e.Layer)));
             AddMissingLayers(existingLayers, Entities.Select(e => e.Layer));
             AddMissingLayers(existingLayers, Objects.OfType<DxfLayerFilter>().SelectMany(l => l.LayerNames));
             AddMissingLayers(existingLayers, Objects.OfType<DxfLayerIndex>().SelectMany(l => l.LayerNames));
-
+            
+            var existingLineTypes = GetExistingNames(LineTypes.Cast<DxfSymbolTableFlags>());
             AddMissingLineTypes(existingLineTypes, new[] { Header.CurrentEntityLineType, Header.DimensionLineType });
             AddMissingLineTypes(existingLineTypes, Layers.Select(l => l.LineTypeName));
             AddMissingLineTypes(existingLineTypes, Blocks.SelectMany(b => b.Entities.Select(e => e.LineTypeName)));
             AddMissingLineTypes(existingLineTypes, Entities.Select(e => e.LineTypeName));
             AddMissingLineTypes(existingLineTypes, Objects.OfType<DxfMLineStyle>().SelectMany(m => m.Elements.Select(e => e.LineType)));
-
+            
+            var existingStyles = GetExistingNames(Styles.Cast<DxfSymbolTableFlags>());
             AddMissingStyles(existingStyles, Entities.OfType<DxfArcAlignedText>().Select(a => a.TextStyleName));
             AddMissingStyles(existingStyles, Entities.OfType<DxfAttribute>().Select(a => a.TextStyleName));
             AddMissingStyles(existingStyles, Entities.OfType<DxfAttributeDefinition>().Select(a => a.TextStyleName));
             AddMissingStyles(existingStyles, Entities.OfType<DxfMText>().Select(m => m.TextStyleName));
             AddMissingStyles(existingStyles, Entities.OfType<DxfText>().Select(t => t.TextStyleName));
             AddMissingStyles(existingStyles, Objects.OfType<DxfMLineStyle>().Select(m => m.StyleName));
-
+            
+            var existingViews = GetExistingNames(Views.Cast<DxfSymbolTableFlags>());
             AddMissingViews(existingViews, Objects.OfType<DxfPlotSettings>().Select(p => p.PlotViewName));
-
+            
+            var existingUcs = GetExistingNames(UserCoordinateSystems.Cast<DxfSymbolTableFlags>());
             AddMissingUcs(existingUcs, new[] {
                 Header.UCSDefinitionName,
                 Header.UCSName,

--- a/src/IxMilia.Dxf/Entities/DxfImage.cs
+++ b/src/IxMilia.Dxf/Entities/DxfImage.cs
@@ -40,10 +40,10 @@ namespace IxMilia.Dxf.Entities
         protected override DxfEntity PostParse()
         {
             Debug.Assert((ClippingVertexCount == _clippingVerticesX.Count) && (ClippingVertexCount == _clippingVerticesY.Count));
-            for (int i = 0; i < this.ClippingVertexCount; i++)
+            for (var i = 0; i < this.ClippingVertexCount; i++)
             {
-                double x = this._clippingVerticesX[i];
-                double y = this._clippingVerticesY[i];
+                var x = this._clippingVerticesX[i];
+                var y = this._clippingVerticesY[i];
                 this.ClippingVertices.Add(new DxfPoint(x, y, 0.0));
             }
 

--- a/src/IxMilia.Dxf/Entities/DxfImage.cs
+++ b/src/IxMilia.Dxf/Entities/DxfImage.cs
@@ -40,9 +40,11 @@ namespace IxMilia.Dxf.Entities
         protected override DxfEntity PostParse()
         {
             Debug.Assert((ClippingVertexCount == _clippingVerticesX.Count) && (ClippingVertexCount == _clippingVerticesY.Count));
-            foreach (var point in _clippingVerticesX.Zip(_clippingVerticesY, (x, y) => new DxfPoint(x, y, 0.0)))
+            for (int i = 0; i < this.ClippingVertexCount; i++)
             {
-                ClippingVertices.Add(point);
+                double x = this._clippingVerticesX[i];
+                double y = this._clippingVerticesY[i];
+                this.ClippingVertices.Add(new DxfPoint(x, y, 0.0));
             }
 
             _clippingVerticesX.Clear();

--- a/src/IxMilia.Dxf/IxMilia.Dxf.csproj
+++ b/src/IxMilia.Dxf/IxMilia.Dxf.csproj
@@ -8,6 +8,7 @@
     <Authors>IxMilia</Authors>
     <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard1.0;net45;net35</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard1.0</TargetFrameworks>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
     <AssemblyName>IxMilia.Dxf</AssemblyName>
     <PackageId>IxMilia.Dxf</PackageId>
     <PackageTags>AutoCAD;CAD;DXB;DXF</PackageTags>

--- a/src/IxMilia.Dxf/IxMilia.Dxf.csproj
+++ b/src/IxMilia.Dxf/IxMilia.Dxf.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>IxMilia.Dxf</AssemblyTitle>
     <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>IxMilia</Authors>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard1.0;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard1.0;net45;net35</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard1.0</TargetFrameworks>
     <AssemblyName>IxMilia.Dxf</AssemblyName>
     <PackageId>IxMilia.Dxf</PackageId>

--- a/src/IxMilia.Dxf/Sections/DxfThumbnailImageSection.cs
+++ b/src/IxMilia.Dxf/Sections/DxfThumbnailImageSection.cs
@@ -108,11 +108,7 @@ namespace IxMilia.Dxf.Sections
 
                 var section = new DxfThumbnailImageSection();
                 section.Clear();
-#if NET35
                 section.RawData = DxfCommonConverters.HexBytes(string.Join(string.Empty, lines.ToArray()));
-#else
-                section.RawData = DxfCommonConverters.HexBytes(string.Join(string.Empty, lines));
-#endif
                 return section;
             }
 

--- a/src/IxMilia.Dxf/Sections/DxfThumbnailImageSection.cs
+++ b/src/IxMilia.Dxf/Sections/DxfThumbnailImageSection.cs
@@ -108,7 +108,11 @@ namespace IxMilia.Dxf.Sections
 
                 var section = new DxfThumbnailImageSection();
                 section.Clear();
+#if NET35
+                section.RawData = DxfCommonConverters.HexBytes(string.Join(string.Empty, lines.ToArray()));
+#else
                 section.RawData = DxfCommonConverters.HexBytes(string.Join(string.Empty, lines));
+#endif
                 return section;
             }
 

--- a/src/IxMilia.Dxf/Tables/DxfSymbolTableFlags.cs
+++ b/src/IxMilia.Dxf/Tables/DxfSymbolTableFlags.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using IxMilia.Dxf.Collections;
 using IxMilia.Dxf.Tables;
 
@@ -153,7 +154,11 @@ namespace IxMilia.Dxf
 
         internal override void AfterRead()
         {
+#if NET35
+            var hex = string.Join(string.Empty, _bitmapPreviewData.ToArray());
+#else
             var hex = string.Join(string.Empty, _bitmapPreviewData);
+#endif
             _bitmapPreviewData.Clear(); // don't keep this around
             BitmapData = DxfCommonConverters.HexBytes(hex);
         }
@@ -185,7 +190,7 @@ namespace IxMilia.Dxf
 
         private string GetWritableLineTypeName(string lineTypeName)
         {
-            return string.IsNullOrWhiteSpace(lineTypeName) ? "CONTINUOUS" : lineTypeName;
+            return Compat.IsNullOrWhiteSpace(lineTypeName) ? "CONTINUOUS" : lineTypeName;
         }
     }
 }

--- a/src/IxMilia.Dxf/Tables/DxfSymbolTableFlags.cs
+++ b/src/IxMilia.Dxf/Tables/DxfSymbolTableFlags.cs
@@ -154,11 +154,7 @@ namespace IxMilia.Dxf
 
         internal override void AfterRead()
         {
-#if NET35
             var hex = string.Join(string.Empty, _bitmapPreviewData.ToArray());
-#else
-            var hex = string.Join(string.Empty, _bitmapPreviewData);
-#endif
             _bitmapPreviewData.Clear(); // don't keep this around
             BitmapData = DxfCommonConverters.HexBytes(hex);
         }

--- a/src/IxMilia.Dxf/Tables/Generated/DxfAppIdTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfAppIdTableGenerated.cs
@@ -17,7 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
+#if NET35
+            return Items.Cast<DxfSymbolTableFlags>();
+#else
             return Items;
+#endif
         }
 
         public DxfAppIdTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfAppIdTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfAppIdTableGenerated.cs
@@ -17,11 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-#if NET35
+        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-#else
+        #else
             return Items;
-#endif
+        #endif
         }
 
         public DxfAppIdTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfAppIdTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfAppIdTableGenerated.cs
@@ -17,11 +17,7 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-        #else
-            return Items;
-        #endif
         }
 
         public DxfAppIdTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfBlockRecordTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfBlockRecordTableGenerated.cs
@@ -17,11 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-#if NET35
+        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-#else
+        #else
             return Items;
-#endif
+        #endif
         }
 
         public DxfBlockRecordTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfBlockRecordTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfBlockRecordTableGenerated.cs
@@ -17,7 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
+#if NET35
+            return Items.Cast<DxfSymbolTableFlags>();
+#else
             return Items;
+#endif
         }
 
         public DxfBlockRecordTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfBlockRecordTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfBlockRecordTableGenerated.cs
@@ -17,11 +17,7 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-        #else
-            return Items;
-        #endif
         }
 
         public DxfBlockRecordTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfDimStyleTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfDimStyleTableGenerated.cs
@@ -18,11 +18,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-#if NET35
+        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-#else
+        #else
             return Items;
-#endif
+        #endif
         }
 
         public DxfDimStyleTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfDimStyleTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfDimStyleTableGenerated.cs
@@ -18,7 +18,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
+#if NET35
+            return Items.Cast<DxfSymbolTableFlags>();
+#else
             return Items;
+#endif
         }
 
         public DxfDimStyleTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfDimStyleTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfDimStyleTableGenerated.cs
@@ -18,11 +18,7 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-        #else
-            return Items;
-        #endif
         }
 
         public DxfDimStyleTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfLTypeTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfLTypeTableGenerated.cs
@@ -17,7 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
+#if NET35
+            return Items.Cast<DxfSymbolTableFlags>();
+#else
             return Items;
+#endif
         }
 
         public DxfLTypeTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfLTypeTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfLTypeTableGenerated.cs
@@ -17,11 +17,7 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-        #else
-            return Items;
-        #endif
         }
 
         public DxfLTypeTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfLTypeTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfLTypeTableGenerated.cs
@@ -17,11 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-#if NET35
+        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-#else
+        #else
             return Items;
-#endif
+        #endif
         }
 
         public DxfLTypeTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfLayerTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfLayerTableGenerated.cs
@@ -17,11 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-#if NET35
+        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-#else
+        #else
             return Items;
-#endif
+        #endif
         }
 
         public DxfLayerTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfLayerTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfLayerTableGenerated.cs
@@ -17,11 +17,7 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-        #else
-            return Items;
-        #endif
         }
 
         public DxfLayerTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfLayerTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfLayerTableGenerated.cs
@@ -17,7 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
+#if NET35
+            return Items.Cast<DxfSymbolTableFlags>();
+#else
             return Items;
+#endif
         }
 
         public DxfLayerTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfStyleTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfStyleTableGenerated.cs
@@ -17,11 +17,7 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-        #else
-            return Items;
-        #endif
         }
 
         public DxfStyleTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfStyleTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfStyleTableGenerated.cs
@@ -17,11 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-#if NET35
+        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-#else
+        #else
             return Items;
-#endif
+        #endif
         }
 
         public DxfStyleTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfStyleTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfStyleTableGenerated.cs
@@ -17,7 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
+#if NET35
+            return Items.Cast<DxfSymbolTableFlags>();
+#else
             return Items;
+#endif
         }
 
         public DxfStyleTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfUcsTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfUcsTableGenerated.cs
@@ -17,11 +17,7 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-        #else
-            return Items;
-        #endif
         }
 
         public DxfUcsTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfUcsTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfUcsTableGenerated.cs
@@ -17,7 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
+#if NET35
+            return Items.Cast<DxfSymbolTableFlags>();
+#else
             return Items;
+#endif
         }
 
         public DxfUcsTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfUcsTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfUcsTableGenerated.cs
@@ -17,11 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-#if NET35
+        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-#else
+        #else
             return Items;
-#endif
+        #endif
         }
 
         public DxfUcsTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfViewPortTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfViewPortTableGenerated.cs
@@ -17,11 +17,7 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-        #else
-            return Items;
-        #endif
         }
 
         public DxfViewPortTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfViewPortTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfViewPortTableGenerated.cs
@@ -17,7 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
+#if NET35
+            return Items.Cast<DxfSymbolTableFlags>();
+#else
             return Items;
+#endif
         }
 
         public DxfViewPortTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfViewPortTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfViewPortTableGenerated.cs
@@ -17,11 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-#if NET35
+        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-#else
+        #else
             return Items;
-#endif
+        #endif
         }
 
         public DxfViewPortTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfViewTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfViewTableGenerated.cs
@@ -17,11 +17,7 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-        #else
-            return Items;
-        #endif
         }
 
         public DxfViewTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfViewTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfViewTableGenerated.cs
@@ -17,11 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
-#if NET35
+        #if NET35
             return Items.Cast<DxfSymbolTableFlags>();
-#else
+        #else
             return Items;
-#endif
+        #endif
         }
 
         public DxfViewTable()

--- a/src/IxMilia.Dxf/Tables/Generated/DxfViewTableGenerated.cs
+++ b/src/IxMilia.Dxf/Tables/Generated/DxfViewTableGenerated.cs
@@ -17,7 +17,11 @@ namespace IxMilia.Dxf.Tables
 
         protected override IEnumerable<DxfSymbolTableFlags> GetSymbolItems()
         {
+#if NET35
+            return Items.Cast<DxfSymbolTableFlags>();
+#else
             return Items;
+#endif
         }
 
         public DxfViewTable()


### PR DESCRIPTION
This PR relates to #85. I've added `net35` as target framework to the csproj and used the `NET35` preprocessor flag to support the old framework, where newer APIs are not available. A new `Compat.cs` class hides some of the ugly preprocessor flag hopping - but thats only a fraction. The following API changes are required for net35:

- generic covariance: explicit `.Cast<T>()` is required. To the best of my knowledge, there is no smart way to extend 3.5 for this to work.
- `string.IsNullOrWhiteSpace` not available, replace with `Compat.IsNullOrWhiteSpace`
- `Guid.TryParse` not available, replace with call to `Compat.cs` 
- Linq `.Zip()` not available, reverted to classic code
- `string.Join` only takes arrays, not IEnumerable. I have added `.ToArray()` calls condintionally iff `NET35`, which looks a little cluttered. Pulling the functionality into `Compat.cs` would require some more work to support all overloads of `string.Join(..)`.

Open for discussion. The most annoying thing with supporting old frameworks is that you can't use modern C# features such as inline out variables (you didn't use them, yet) or throw-if-null-asignment in one line. The good thing is, that Visual Studio will compile for all target frameworks and you immediately get feedback. At our company, we have different Visual Studio solutions compiling for different target frameworks and you have to open both to check compatibility (terrible).

Question: I changed the main library directly - your code generation tool might override any changes? Do I have to adapt the `IxMilia.Dxf.Generator` instead? I have no idea, what it does or how it works.