### PR TITLE
ensure DxfPlotSettings.PlotViewName is always useful.

### DIFF
--- a/src/IxMilia.Dxf.Generator/Specs/ObjectsSpec.xml
+++ b/src/IxMilia.Dxf.Generator/Specs/ObjectsSpec.xml
@@ -346,8 +346,8 @@
     LAYOUT
 
     -->
-    <Object Name="DxfLayout" ObjectType="Layout" SubclassMarker="AcDbLayout" TypeString="LAYOUT" BaseClass="DxfPlotSettings" GenerateReaderFunction="false" MinVersion="R2000">
-        <Property Name="LayoutName" Code="1" Type="string" DefaultValue="null" />
+    <Object Name="DxfLayout" ObjectType="Layout" SubclassMarker="AcDbLayout" TypeString="LAYOUT" BaseClass="DxfPlotSettings" GenerateReaderFunction="false" DefaultConstructor="Internal" MinVersion="R2000">
+        <Property Name="_layoutName" Code="1" Type="string" DefaultValue="null" Accessibility="private" />
         <Property Name="LayoutFlags" Code="70" Type="int" DefaultValue="0" WriteConverter="(short)">
             <Flag Name="IsPsLtScale" Mask="1" />
             <Flag Name="IsLimCheck" Mask="2" />
@@ -709,11 +709,11 @@
     PLOTSETTINGS
 
     -->
-    <Object Name="DxfPlotSettings" ObjectType="PlotSettings" SubclassMarker="AcDbPlotSettings" TypeString="PLOTSETTINGS" MinVersion="R2000">
+    <Object Name="DxfPlotSettings" ObjectType="PlotSettings" SubclassMarker="AcDbPlotSettings" TypeString="PLOTSETTINGS" DefaultConstructor="Internal" MinVersion="R2000">
         <Property Name="PageSetupName" Code="1" Type="string" DefaultValue="null" />
         <Property Name="PrinterName" Code="2" Type="string" DefaultValue="null" />
         <Property Name="PaperSize" Code="4" Type="string" DefaultValue="null" />
-        <Property Name="PlotViewName" Code="6" Type="string" DefaultValue="null" />
+        <Property Name="_plotViewName" Code="6" Type="string" DefaultValue="null" Accessibility="private" />
         <Property Name="UnprintableLeftMarginSize" Code="40" Type="double" DefaultValue="0.0" />
         <Property Name="UnprintableBottomMarginSize" Code="41" Type="double" DefaultValue="0.0" />
         <Property Name="UnprintableRightMarginSize" Code="42" Type="double" DefaultValue="0.0" />

--- a/src/IxMilia.Dxf/DxfFile.cs
+++ b/src/IxMilia.Dxf/DxfFile.cs
@@ -548,7 +548,7 @@ namespace IxMilia.Dxf
         {
             foreach (var itemToAdd in itemsToAdd)
             {
-                if (itemToAdd != null && !existingItems.Contains(itemToAdd))
+                if (!string.IsNullOrEmpty(itemToAdd) && !existingItems.Contains(itemToAdd))
                 {
                     addItem(itemToAdd);
                     existingItems.Add(itemToAdd);

--- a/src/IxMilia.Dxf/Objects/DxfLayout.cs
+++ b/src/IxMilia.Dxf/Objects/DxfLayout.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) IxMilia.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System;
 
 namespace IxMilia.Dxf.Objects
 {
@@ -17,6 +17,32 @@ namespace IxMilia.Dxf.Objects
 
     public partial class DxfLayout
     {
+        public string LayoutName
+        {
+            get => _layoutName;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new InvalidOperationException($"{nameof(LayoutName)} must be non-empty.");
+                }
+
+                _layoutName = value;
+            }
+        }
+
+        public override string PlotViewName
+        {
+            get => string.IsNullOrEmpty(base.PlotViewName) ? LayoutName : base.PlotViewName;
+            set => base.PlotViewName = value;
+        }
+
+        public DxfLayout(string plotViewName, string layoutName)
+            : base(plotViewName)
+        {
+            LayoutName = layoutName;
+        }
+
         public IDxfItem PaperSpaceObject
         {
             get { return Owner; }

--- a/src/IxMilia.Dxf/Objects/DxfPlotSettings.cs
+++ b/src/IxMilia.Dxf/Objects/DxfPlotSettings.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) IxMilia.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+
 namespace IxMilia.Dxf.Objects
 {
     public enum DxfPlotPaperUnits
@@ -84,5 +86,24 @@ namespace IxMilia.Dxf.Objects
 
     public partial class DxfPlotSettings
     {
+        public virtual string PlotViewName
+        {
+            get => _plotViewName;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new InvalidOperationException($"{nameof(PlotViewName)} must be non-empty.");
+                }
+
+                _plotViewName = value;
+            }
+        }
+
+        public DxfPlotSettings(string plotViewName)
+            : this()
+        {
+            PlotViewName = plotViewName;
+        }
     }
 }


### PR DESCRIPTION
Also only expose valid constructors for DxfLayout and DxfPlotSettings.

Fixes #81.
Fixes #94.
