### PR TITLE
Replace Spline Weight by Weights

### DIFF
--- a/src/IxMilia.Dxf.Generator/Specs/EntitiesSpec.xml
+++ b/src/IxMilia.Dxf.Generator/Specs/EntitiesSpec.xml
@@ -1136,7 +1136,7 @@
         <Property Name="StartTangent" Code="12" Type="DxfPoint" DefaultValue="DxfPoint.Origin" CodeOverrides="12,22,32" />
         <Property Name="EndTangent" Code="13" Type="DxfPoint" DefaultValue="DxfPoint.Origin" CodeOverrides="13,23,33" />
         <Property Name="KnotValues" Code="40" Type="double" DefaultValue="" AllowMultiples="true" />
-        <Property Name="Weight" Code="41" Type="double" DefaultValue="1.0" DisableWritingDefault="true" />
+        <Property Name="Weights" Code="41" Type="double" DefaultValue="" AllowMultiples="true" />
         <Property Name="_controlPointX" Code="10" Type="double" DefaultValue="" AllowMultiples="true" Accessibility="private" />
         <Property Name="_controlPointY" Code="20" Type="double" DefaultValue="" AllowMultiples="true" Accessibility="private" />
         <Property Name="_controlPointZ" Code="30" Type="double" DefaultValue="" AllowMultiples="true" Accessibility="private" />
@@ -1157,7 +1157,9 @@
             <WriteProperty Property="StartTangent" />
             <WriteProperty Property="EndTangent" />
             <WriteProperty Property="KnotValues" />
-            <WriteProperty Property="Weight" />
+            <Foreach Property="Weights">
+              <WriteSpecificValue Code="41" Value="item" />
+            </Foreach>
             <Foreach Property="ControlPoints">
                 <WriteSpecificValue Code="10" Value="item.X" />
                 <WriteSpecificValue Code="20" Value="item.Y" />

--- a/src/IxMilia.Dxf/Entities/DxfSpline.cs
+++ b/src/IxMilia.Dxf/Entities/DxfSpline.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using IxMilia.Dxf.Collections;
+using System.Linq;
 
 namespace IxMilia.Dxf.Entities
 {
@@ -35,6 +36,11 @@ namespace IxMilia.Dxf.Entities
                 ControlPoints.Add(new DxfPoint(_controlPointX[i], _controlPointY[i], _controlPointZ[i]));
             }
 
+            if(Weights.Count != ControlPoints.Count)
+            {
+                Weights = ControlPoints.Select(curr => 1.0).ToArray();
+            }
+            
             _controlPointX.Clear();
             _controlPointY.Clear();
             _controlPointZ.Clear();


### PR DESCRIPTION
Replaced the Property Weight by a property Weights which includes a weight entry for each control point. If the entries between control points and weights do not match, they are replaced with "1.0", the default value for weights.

This pull request corresponds to issue https://github.com/IxMilia/Dxf/issues/98