### PR TITLE
Set default layer for DxfBlock

### DIFF
--- a/src/IxMilia.Dxf/Blocks/DxfBlock.cs
+++ b/src/IxMilia.Dxf/Blocks/DxfBlock.cs
@@ -95,6 +95,7 @@ namespace IxMilia.Dxf.Blocks
 
         public DxfBlock()
         {
+            Layer = "0";
             BasePoint = DxfPoint.Origin;
             Entities = new ListNonNull<DxfEntity>();
             ExtensionDataGroups = new ListNonNull<DxfCodePairGroup>();


### PR DESCRIPTION
`DxfBlock.Layer` is not initialized (`null`) unless set explicitely. Setting a default value of `"0"` should improve compatibility with other readers/CAD applications.

Related to #100 (but does not solve it).