### PR TITLE
read/write unicode string values

### DIFF
--- a/src/IxMilia.Dxf.Test/AbstractDxfTests.cs
+++ b/src/IxMilia.Dxf.Test/AbstractDxfTests.cs
@@ -16,7 +16,7 @@ namespace IxMilia.Dxf.Test
         protected static DxfFile Parse(string data)
         {
             using (var ms = new MemoryStream())
-            using (var writer = new StreamWriter(ms))
+            using (var writer = new StreamWriter(ms, Encoding.UTF8))
             {
                 writer.WriteLine(data.Trim());
                 writer.Flush();
@@ -166,6 +166,7 @@ EOF
                     case ')':
                     case '?':
                     case '*':
+                    case '+':
                     case '$':
                     case '^':
                         // escape special characters

--- a/src/IxMilia.Dxf/DxfBinaryReader.cs
+++ b/src/IxMilia.Dxf/DxfBinaryReader.cs
@@ -36,6 +36,11 @@ namespace IxMilia.Dxf
             }
         }
 
+        public void SetUtf8Reader()
+        {
+            // noop
+        }
+
         private DxfCodePair GetCodePair()
         {
             var codeOffset = _totalBytesRead + _miniBufferStart;

--- a/src/IxMilia.Dxf/DxfCodePairBufferReader.cs
+++ b/src/IxMilia.Dxf/DxfCodePairBufferReader.cs
@@ -41,9 +41,17 @@ namespace IxMilia.Dxf
 
     internal class DxfCodePairBufferReader : DxfBufferReader<DxfCodePair>
     {
-        public DxfCodePairBufferReader(IEnumerable<DxfCodePair> pairs)
-            : base(pairs, (pair) => pair.Code == 999)
+        private IDxfCodePairReader reader;
+
+        public DxfCodePairBufferReader(IDxfCodePairReader reader)
+            : base(reader.GetCodePairs(), (pair) => pair.Code == 999)
         {
+            this.reader = reader;
+        }
+
+        public void SetUtf8Reader()
+        {
+            reader.SetUtf8Reader();
         }
     }
 }

--- a/src/IxMilia.Dxf/Extensions/StreamExtensions.cs
+++ b/src/IxMilia.Dxf/Extensions/StreamExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) IxMilia.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+
+namespace IxMilia.Dxf.Extensions
+{
+    internal static class StreamExtensions
+    {
+        public static string ReadLine(this Stream stream, out int bytesRead)
+        {
+            // read line char-by-char
+            var sb = new StringBuilder();
+            var b = stream.ReadByte();
+            bytesRead = 1;
+            if (b < 0)
+            {
+                return null;
+            }
+
+            var c = (char)b;
+            while (b > 0 && c != '\n')
+            {
+                sb.Append(c);
+                b = stream.ReadByte();
+                bytesRead++;
+                c = (char)b;
+            }
+
+            if (sb.Length > 0 && sb[sb.Length - 1] == '\r')
+            {
+                sb.Remove(sb.Length - 1, 1);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/IxMilia.Dxf/IDxfCodePairReader.cs
+++ b/src/IxMilia.Dxf/IDxfCodePairReader.cs
@@ -7,5 +7,6 @@ namespace IxMilia.Dxf
     internal interface IDxfCodePairReader
     {
         IEnumerable<DxfCodePair> GetCodePairs();
+        void SetUtf8Reader();
     }
 }

--- a/src/IxMilia.Dxf/Sections/DxfHeaderSection.cs
+++ b/src/IxMilia.Dxf/Sections/DxfHeaderSection.cs
@@ -439,6 +439,11 @@ namespace IxMilia.Dxf.Sections
                 else
                 {
                     section.Header.SetHeaderVariable(keyName, pair);
+                    if (string.Compare(keyName, "$ACADVER", StringComparison.OrdinalIgnoreCase) == 0 && section.Header.Version >= DxfAcadVersion.R2007)
+                    {
+                        // R2007 and up should switch to a UTF8 reader
+                        buffer.SetUtf8Reader();
+                    }
                 }
             }
 


### PR DESCRIPTION
According to the spec it's unknown if the file can be read as UTF-8 until the version in the header has been encountered, hence the switch to the UTF-8 reader if `$ACADVER >= AC1021`.  If that switch wasn't made, UTF-8 characters are specified with the well-known `\U+xxxx` sequence.

Fixes #107.
Fixes #108.