### PR TITLE
Improve Autodesk compatibility

### DIFF
--- a/src/IxMilia.Dxf/Entities/DxfVertex.cs
+++ b/src/IxMilia.Dxf/Entities/DxfVertex.cs
@@ -55,7 +55,7 @@ namespace IxMilia.Dxf.Entities
                 }
             }
 
-            if (version >= DxfAcadVersion.R2010)
+            if (version >= DxfAcadVersion.R2010 && Identifier != 0)
             {
                 pairs.Add(new DxfCodePair(91, Identifier));
             }


### PR DESCRIPTION
Do not write Vertex.Identifier (Code 91) if the identifier was not set. AutoCAD and True View will crash if zero identifiers are written with the error message.

```
The following error was encountered while reading
in VERTEX starting at line 28046:
Unexpected DXF group code: 91
Invalid or incomplete DXF input -- drawing discarded.
```