### PR TITLE
Assign handles to Block.Entities (improve Autodesk compatibility)

### DIFF
--- a/src/IxMilia.Dxf.Generator/Specs/EntitiesSpec.xml
+++ b/src/IxMilia.Dxf.Generator/Specs/EntitiesSpec.xml
@@ -363,7 +363,7 @@
     <!-- the class from which all dimensions inherit -->
     <Entity Name="DxfDimensionBase" EntityType="Dimension" SubclassMarker="AcDbDimension" TypeString="DIMENSION" DefaultConstructor="Internal" CopyConstructor="Protected" HasXData="true">
         <Property Name="Version" Code="280" Type="DxfVersion" DefaultValue="DxfVersion.R2010" ReadConverter="(DxfVersion){0}" WriteConverter="(short){0}" MinVersion="R2010" />
-        <Property Name="BlockName" Code="2" Type="string" DefaultValue="*MODEL_SPACE" />
+        <Property Name="BlockName" Code="2" Type="string" DefaultValue="null" DisableWritingDefault="true" />
         <Property Name="DefinitionPoint1" Code="10" Type="DxfPoint" DefaultValue="DxfPoint.Origin" CodeOverrides="10,20,30" />
         <Property Name="TextMidPoint" Code="11" Type="DxfPoint" DefaultValue="DxfPoint.Origin" CodeOverrides="11,21,31" />
         <Property Name="DimensionType" Code="70" Type="DxfDimensionType" DefaultValue="DxfDimensionType.Aligned" ReadConverter="HandleDimensionType({0})" WriteConverter="HandleDimensionType({0})" />

--- a/src/IxMilia.Dxf.Test/DxfEntityTests.cs
+++ b/src/IxMilia.Dxf.Test/DxfEntityTests.cs
@@ -163,7 +163,7 @@ AcDbEntity
         public void DimensionDefaultValuesTest()
         {
             var dim = new DxfAlignedDimension();
-            Assert.Equal("*MODEL_SPACE", dim.BlockName);
+            Assert.Null(dim.BlockName);
             Assert.Equal("STANDARD", dim.DimensionStyleName);
         }
 
@@ -1329,8 +1329,6 @@ bar
 7
 100
 AcDbDimension
-  2
-*MODEL_SPACE
  10
 330.25
  20

--- a/src/IxMilia.Dxf.Test/DxfObjectTests.cs
+++ b/src/IxMilia.Dxf.Test/DxfObjectTests.cs
@@ -513,11 +513,13 @@ ACDBDICTIONARYWDFLT
 AcDbDictionary
 281
 0
-340
-#
   3
 key-1
 350
+#
+100
+AcDbDictionaryWithDefault
+340
 #
   0
 DICTIONARYVAR

--- a/src/IxMilia.Dxf/Blocks/DxfBlock.cs
+++ b/src/IxMilia.Dxf/Blocks/DxfBlock.cs
@@ -31,7 +31,14 @@ namespace IxMilia.Dxf.Blocks
         }
         IEnumerable<IDxfItemInternal> IDxfItemInternal.GetChildItems()
         {
-            return ((IDxfItemInternal)this).GetPointers().Select(p => (IDxfItemInternal)p.Item);
+            foreach (var entity in Entities)
+            {
+                yield return entity;
+            }
+            foreach (var pointer in ((IDxfItemInternal)this).GetPointers())
+            {
+                yield return (IDxfItemInternal)pointer.Item;
+            }
         }
 
         private DxfPointer _endBlockPointer { get; } = new DxfPointer();
@@ -157,8 +164,8 @@ namespace IxMilia.Dxf.Blocks
                 list.Add(new DxfCodePair(4, Description));
             }
 
-            // entities in blocks never have handles
-            list.AddRange(Entities.SelectMany(e => e.GetValuePairs(version, outputHandles: false)));
+            // entities in blocks need handles for some applications
+            list.AddRange(Entities.SelectMany(e => e.GetValuePairs(version, outputHandles)));
 
             list.AddRange(EndBlock.GetValuePairs(version, outputHandles));
 

--- a/src/IxMilia.Dxf/Objects/DxfDictionaryWithDefault.cs
+++ b/src/IxMilia.Dxf/Objects/DxfDictionaryWithDefault.cs
@@ -31,15 +31,20 @@ namespace IxMilia.Dxf.Objects
                 pairs.Add(new DxfCodePair(281, (short)(this.DuplicateRecordHandling)));
             }
 
-            if (DefaultObject != null && DefaultObjectPointer.Handle != 0u)
-            {
-                pairs.Add(new DxfCodePair(340, UIntHandle(DefaultObjectPointer.Handle)));
-            }
-
             foreach (var item in _items.OrderBy(kvp => kvp.Key))
             {
                 pairs.Add(new DxfCodePair(3, item.Key));
                 pairs.Add(new DxfCodePair(350, UIntHandle(item.Value.Handle)));
+            }
+
+
+            if (version >= DxfAcadVersion.R2000)
+            {
+                pairs.Add(new DxfCodePair(100, "AcDbDictionaryWithDefault"));
+                if (DefaultObject != null && DefaultObjectPointer.Handle != 0u)
+                {
+                    pairs.Add(new DxfCodePair(340, UIntHandle(DefaultObjectPointer.Handle)));
+                }
             }
         }
 


### PR DESCRIPTION
resolves #100 