### PR TITLE
Dimension entities should only write BlockName if set explicitely

### DIFF
--- a/src/IxMilia.Dxf.Generator/Specs/EntitiesSpec.xml
+++ b/src/IxMilia.Dxf.Generator/Specs/EntitiesSpec.xml
@@ -363,7 +363,7 @@
     <!-- the class from which all dimensions inherit -->
     <Entity Name="DxfDimensionBase" EntityType="Dimension" SubclassMarker="AcDbDimension" TypeString="DIMENSION" DefaultConstructor="Internal" CopyConstructor="Protected" HasXData="true">
         <Property Name="Version" Code="280" Type="DxfVersion" DefaultValue="DxfVersion.R2010" ReadConverter="(DxfVersion){0}" WriteConverter="(short){0}" MinVersion="R2010" />
-        <Property Name="BlockName" Code="2" Type="string" DefaultValue="*MODEL_SPACE" />
+        <Property Name="BlockName" Code="2" Type="string" DefaultValue="null" DisableWritingDefault="true" />
         <Property Name="DefinitionPoint1" Code="10" Type="DxfPoint" DefaultValue="DxfPoint.Origin" CodeOverrides="10,20,30" />
         <Property Name="TextMidPoint" Code="11" Type="DxfPoint" DefaultValue="DxfPoint.Origin" CodeOverrides="11,21,31" />
         <Property Name="DimensionType" Code="70" Type="DxfDimensionType" DefaultValue="DxfDimensionType.Aligned" ReadConverter="HandleDimensionType({0})" WriteConverter="HandleDimensionType({0})" />

--- a/src/IxMilia.Dxf.Test/DxfEntityTests.cs
+++ b/src/IxMilia.Dxf.Test/DxfEntityTests.cs
@@ -163,7 +163,7 @@ AcDbEntity
         public void DimensionDefaultValuesTest()
         {
             var dim = new DxfAlignedDimension();
-            Assert.Equal("*MODEL_SPACE", dim.BlockName);
+            Assert.Null(dim.BlockName);
             Assert.Equal("STANDARD", dim.DimensionStyleName);
         }
 
@@ -1329,8 +1329,6 @@ bar
 7
 100
 AcDbDimension
-  2
-*MODEL_SPACE
  10
 330.25
  20


### PR DESCRIPTION
Dimensioning is an important aspect of CAD drawings, but the related objects and styles have a ton of properties - it is very tricky to create a simple dimension entity that AutoCAD, ProgeCAD, QCAD (based on the open source `dxflib`), and the ODA libraries accept without crash _and_ display properly.

Every application will create a very different set of entities, blocks, styles, and associativity objects for a single simple dimension from `A` to `B`. While QCAD will create one single minimalistic entity (a dimension entity, actually), AutoCAD and ProgeCAD will create a dimension entity _and_ a special block with lines, solids, mtext, and what not to actually draw the dimension explicitly, and on top some associativity object to entangle all those entities.

I've experimented quite a lot and inspected the generated DXF by each application - AutoCAD and ProgeCAD generate way to complex stuff (I'm lost). QCAD generates something similar to this library, but reading the QCAD file with IxMilia.DXF and writing it back will corrupt the entity by adding the default `BlockName = "*MODEL_SPACE"` which sounds useful, but makes AutoCAD crash and ProgeCAD simply not display the dimension at all. This PR removes the default value and, if `null`, the code 2 is not written at all. For my very limited test, all applications then read and display the dimension correctly.

Just for completeness, this is my test code:

```cs
DxfPoint a = new DxfPoint(10, 10, 0); // from A
DxfPoint b = new DxfPoint(20, 20, 0); // to   B
DxfPoint c = new DxfPoint(10, 15, 0); // dimension line parallel to AB through this point
DxfAlignedDimension dim = new DxfAlignedDimension
{
    Layer = "0",
    DefinitionPoint2 = a, // [WCS] 3D Point A
    DefinitionPoint3 = b, // [WCS] 3D Point B
    DefinitionPoint1 = c, // [WCS] line parallel to AB through this point
    AttachmentPoint = DxfAttachmentPoint.MiddleCenter,
    //BlockName = "*MODEL_SPACE", // IxMilia default
    //BlockName = null // otherwise AutoCAD will die, ProgeCAD won't show it
};
```