### PR TITLE
Write missing subclass marker for DxfDictionaryWithDefault

### DIFF
--- a/src/IxMilia.Dxf.Test/DxfObjectTests.cs
+++ b/src/IxMilia.Dxf.Test/DxfObjectTests.cs
@@ -513,11 +513,13 @@ ACDBDICTIONARYWDFLT
 AcDbDictionary
 281
 0
-340
-#
   3
 key-1
 350
+#
+100
+AcDbDictionaryWithDefault
+340
 #
   0
 DICTIONARYVAR

--- a/src/IxMilia.Dxf/Objects/DxfDictionaryWithDefault.cs
+++ b/src/IxMilia.Dxf/Objects/DxfDictionaryWithDefault.cs
@@ -31,15 +31,20 @@ namespace IxMilia.Dxf.Objects
                 pairs.Add(new DxfCodePair(281, (short)(this.DuplicateRecordHandling)));
             }
 
-            if (DefaultObject != null && DefaultObjectPointer.Handle != 0u)
-            {
-                pairs.Add(new DxfCodePair(340, UIntHandle(DefaultObjectPointer.Handle)));
-            }
-
             foreach (var item in _items.OrderBy(kvp => kvp.Key))
             {
                 pairs.Add(new DxfCodePair(3, item.Key));
                 pairs.Add(new DxfCodePair(350, UIntHandle(item.Value.Handle)));
+            }
+
+
+            if (version >= DxfAcadVersion.R2000)
+            {
+                pairs.Add(new DxfCodePair(100, "AcDbDictionaryWithDefault"));
+                if (DefaultObject != null && DefaultObjectPointer.Handle != 0u)
+                {
+                    pairs.Add(new DxfCodePair(340, UIntHandle(DefaultObjectPointer.Handle)));
+                }
             }
         }
 


### PR DESCRIPTION
Currently, this library does not write the `AcDbDictionaryWithDefault` subclass marker (code 100) which leads to unexpected crashes of Autodesk applications. Furthermore, I changed the order according to the spec (first available in R2000) and prevent writing of the subclass marker + default object pointer, if version is less than R2000. Eventually, it becomes a regular dictionary, but I didn't test.

What is your strategy when objects are written that do not exist in the selected version? I remember, there was a discussion about throwing or not throwing exceptions in such a case.