### PR TITLE
Add netstandard2.0 target.

### DIFF
--- a/src/IxMilia.Dxf/IxMilia.Dxf.csproj
+++ b/src/IxMilia.Dxf/IxMilia.Dxf.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright 2018</Copyright>
     <AssemblyTitle>IxMilia.Dxf</AssemblyTitle>
     <Authors>IxMilia</Authors>
-    <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Unix'">$(TargetFrameworks);net35;net45</TargetFrameworks>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
     <AssemblyName>IxMilia.Dxf</AssemblyName>
@@ -22,7 +22,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net45'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net45'">
     <DefineConstants>$(DefineConstants);HAS_FILESYSTEM_ACCESS</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
This reduces the number of dependencies for consumers running on .NET Standard 2.0 compatible frameworks.

Source: https://github.com/dotnet/standard/blob/master/docs/versions.md#how-do-i-know-which-net-standard-version-i-should-target