### PR TITLE
always build all frameworks

### DIFF
--- a/build-and-test.cmd
+++ b/build-and-test.cmd
@@ -13,8 +13,6 @@ if /i "%1" == "-notest" goto set_notest
 if /i "%1" == "--notest" goto set_notest
 if /i "%1" == "-oldsdk" goto set_oldsdk
 if /i "%1" == "--oldsdk" goto set_oldsdk
-if /i "%1" == "-portable" goto set_portable
-if /i "%1" == "--portable" goto set_portable
 
 echo Unsupported argument: %1
 goto error
@@ -32,11 +30,6 @@ goto parseargs
 
 :set_oldsdk
 set BuildWithOldSdk=true
-shift
-goto parseargs
-
-:set_portable
-set PortableOnly=true
 shift
 goto parseargs
 

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -17,9 +17,6 @@ while [ $# -gt 0 ]; do
     --oldsdk)
       BuildWithOldSdk=true
       ;;
-    --portable)
-      # noop
-      ;;
     *)
       echo "Invalid argument: $1"
       exit 1

--- a/src/IxMilia.Dxf/IxMilia.Dxf.csproj
+++ b/src/IxMilia.Dxf/IxMilia.Dxf.csproj
@@ -5,9 +5,7 @@
     <Copyright>Copyright 2020</Copyright>
     <AssemblyTitle>IxMilia.Dxf</AssemblyTitle>
     <Authors>IxMilia</Authors>
-    <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix' and '$(PortableOnly)' != 'true'">$(TargetFrameworks);net35;net45</TargetFrameworks>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
+    <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0;net35;net45</TargetFrameworks>
     <AssemblyName>IxMilia.Dxf</AssemblyName>
     <PackageId>IxMilia.Dxf</PackageId>
     <PackageTags>AutoCAD;CAD;DXB;DXF</PackageTags>
@@ -27,6 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
@nzain I'm experimenting with building `net35` and `net45` TFMs on all platforms.  Ideally this would have no negative effect in VS 2017, but I'd appreciate it if you could give this a shot to make sure I didn't break your workflow.

(This is, of course, assuming you still need `net35` and `net45` assemblies.)