### PR TITLE
Implement Missing DxfLwPolyline.GetBoundingBox

### DIFF
--- a/src/IxMilia.Dxf.Test/BoundingBoxTests.cs
+++ b/src/IxMilia.Dxf.Test/BoundingBoxTests.cs
@@ -25,7 +25,7 @@ namespace IxMilia.Dxf.Test
         }
 
         [Fact]
-        public void PolyLineVertexBulgeIsRespected()
+        public void UnclosedPolyLineVertexBulgeIsRespected()
         {
             // Data from https://github.com/ixmilia/dxf/issues/102
             var vertices = new[]
@@ -37,7 +37,29 @@ namespace IxMilia.Dxf.Test
             };
             var poly = new DxfPolyline(vertices) {IsClosed = false};
             var expectedMin = new DxfPoint(-2.0, -0.5, 0);
-            var expectedMax = new DxfPoint(+0.5, +0.5, 0);
+            var expectedMax = new DxfPoint(0, +0.5, 0);
+            var expectedSize = new DxfVector(2.0, 1.0, 0);
+
+            var bb = poly.GetBoundingBox().Value;
+            Assert.Equal(expectedMin, bb.MinimumPoint);
+            Assert.Equal(expectedMax, bb.MaximumPoint);
+            Assert.Equal(expectedSize, bb.Size);
+        }
+
+        [Fact]
+        public void ClosedPolyLineVertexBulgeIsRespected()
+        {
+            // Data from https://github.com/ixmilia/dxf/issues/102
+            var vertices = new[]
+            {
+                new DxfVertex(new DxfPoint(0, +0.5, 0)),
+                new DxfVertex(new DxfPoint(-1.5, +0.5, 0)) {Bulge = 1},
+                new DxfVertex(new DxfPoint(-1.5, -0.5, 0)),
+                new DxfVertex(new DxfPoint(0, -0.5, 0)) {Bulge = 1}
+            };
+            var poly = new DxfPolyline(vertices) {IsClosed = true};
+            var expectedMin = new DxfPoint(-2.0, -0.5, 0);
+            var expectedMax = new DxfPoint(0.5, +0.5, 0);
             var expectedSize = new DxfVector(2.5, 1.0, 0);
 
             var bb = poly.GetBoundingBox().Value;

--- a/src/IxMilia.Dxf/Entities/DxfArc.cs
+++ b/src/IxMilia.Dxf/Entities/DxfArc.cs
@@ -4,12 +4,11 @@ namespace IxMilia.Dxf.Entities
 {
     public partial class DxfArc
     {
-        public static bool TryCreateFromVertices(DxfVertex v1, DxfVertex v2, out DxfArc arc)
+        public static bool TryCreateFromVertices(double x1, double y1, double bulge, double x2, double y2, out DxfArc arc)
         {
             // To the best of my knowledge, 3D Arcs are not defined via z but a normal vector.
             // Thus, simply ignore non-zero z values.
-            
-            var bulge = v1.Bulge;
+
             if (Math.Abs(bulge) < 1e-10)
             {
                 //throw new ArgumentException("arc bulge too small: " + bulge);
@@ -17,11 +16,10 @@ namespace IxMilia.Dxf.Entities
                 return false;
             }
 
-            var startPoint = v1.Location;
-            var endPoint = v2.Location;
-            var delta = endPoint - startPoint;
-            var length = delta.Length;
-            if (length <= double.Epsilon)
+            var deltaX = x2 - x1;
+            var deltaY = y2 - y1;
+            var deltaLength = Math.Sqrt(deltaX * deltaX + deltaY * deltaY);
+            if (deltaLength < 1e-10)
             {
                 //throw new ArgumentException("arc startpoint == endpoint");
                 arc = null;
@@ -29,37 +27,50 @@ namespace IxMilia.Dxf.Entities
             }
 
             var alpha = 4.0 * Math.Atan(bulge);
-            var radius = length / (2.0 * Math.Abs(Math.Sin(alpha * 0.5)));
-            var deltaNorm = delta.Normalize();
+            var radius = deltaLength / (2.0 * Math.Abs(Math.Sin(alpha * 0.5)));
+            var deltaNormX = deltaX / deltaLength;
+            var deltaNormY = deltaY / deltaLength;
             int bulgeSign = Math.Sign(bulge);
 
             // 2D only solution (z=0)
-            var normal = new DxfVector(-deltaNorm.Y, +deltaNorm.X, 0.0) * bulgeSign;
-            var center = (startPoint + endPoint) * 0.5
-                + normal * Math.Cos(alpha * 0.5) * radius;
+            var normalX = -deltaNormX * bulgeSign;
+            var normalY = +deltaNormY * bulgeSign;
+
+            var centerX = (x1 + x2) * 0.5 + normalX * Math.Cos(alpha * 0.5) * radius;
+            var centerY = (y1 + y2) * 0.5 + normalY * Math.Cos(alpha * 0.5) * radius;
 
             // bulge<0 indicates CW arc, but DxfArc is CCW always
             double startAngleDeg;
             double endAngleDeg;
             if (bulge > 0)
             {
-                startAngleDeg = NormalizedAngleDegree(startPoint, center);
-                endAngleDeg = NormalizedAngleDegree(endPoint, center);
+                startAngleDeg = NormalizedAngleDegree(x1, y1, centerX, centerY);
+                endAngleDeg = NormalizedAngleDegree(x2, y2, centerX, centerY);
             }
             else
             {
-                endAngleDeg = NormalizedAngleDegree(startPoint, center);
-                startAngleDeg = NormalizedAngleDegree(endPoint, center);
+                endAngleDeg = NormalizedAngleDegree(x1, y1, centerX, centerY);
+                startAngleDeg = NormalizedAngleDegree(x2, y2, centerX, centerY);
             }
 
-            arc = new DxfArc(center, radius, startAngleDeg, endAngleDeg);
+            arc = new DxfArc(new DxfPoint(centerX, centerY, 0), radius, startAngleDeg, endAngleDeg);
             return true;
         }
 
-        private static double NormalizedAngleDegree(DxfPoint p, DxfPoint center)
+        public static bool TryCreateFromVertices(DxfVertex v1, DxfVertex v2, out DxfArc arc)
         {
-            var dx = p.X - center.X;
-            var dy = p.Y - center.Y;
+            return TryCreateFromVertices(v1.Location.X, v1.Location.Y, v1.Bulge, v2.Location.X, v2.Location.Y, out arc);
+        }
+        
+        public static bool TryCreateFromVertices(DxfLwPolylineVertex v1, DxfLwPolylineVertex v2, out DxfArc arc)
+        {
+            return TryCreateFromVertices(v1.X, v1.Y, v1.Bulge, v2.X, v2.Y, out arc);
+        }
+
+        private static double NormalizedAngleDegree(double pX, double pY, double centerX, double centerY)
+        {
+            var dx = pX - centerX;
+            var dy = pY - centerY;
             var angle = Math.Atan2(dy, dx);
             if (angle < 0)
             {


### PR DESCRIPTION
Actually just a copy-paste from ```DxfPolyline``` calculation. Fixed a lot of things in my project.

Small suggestion: Implement ```DxfArc.TryCreateFromVertices(DxfLwPolylineVertex, DxfLwPolylineVertex, out var arc)``` to not create any temp objects