### PR TITLE
Standard coordinates separator

### DIFF
--- a/src/IxMilia.Dxf/DxfVector.cs
+++ b/src/IxMilia.Dxf/DxfVector.cs
@@ -134,7 +134,7 @@ namespace IxMilia.Dxf
 
         public override string ToString()
         {
-            return string.Format("({0},{1},{2})", X, Y, Z);
+            return string.Format("({0};{1};{2})", X, Y, Z);
         }
 
         public static DxfVector RightVectorFromNormal(DxfVector normal)


### PR DESCRIPTION
In some languages the separators '.' and ',' have different meanings; better to use the ';' like Microsoft does