### PR TITLE
Standard coordinates separator

### DIFF
--- a/src/IxMilia.Dxf/DxfPoint.cs
+++ b/src/IxMilia.Dxf/DxfPoint.cs
@@ -68,7 +68,7 @@ namespace IxMilia.Dxf
 
         public override string ToString()
         {
-            return string.Format("({0},{1},{2})", X, Y, Z);
+            return string.Format("({0};{1};{2})", X, Y, Z);
         }
 
         public static DxfPoint Origin


### PR DESCRIPTION
In some languages the separators '.' and ',' have different meanings; better to use the ';' like Microsoft does