### PR TITLE
add additional objects of entities in blocks section

### DIFF
--- a/src/IxMilia.Dxf/DxfFile.cs
+++ b/src/IxMilia.Dxf/DxfFile.cs
@@ -418,6 +418,19 @@ namespace IxMilia.Dxf
                         }
                     }
                 }
+
+                if (section is DxfBlocksSection)
+                {
+                    var blocksSection = (DxfBlocksSection)section;
+                    var addedObjects = new HashSet<DxfObject>(Objects);
+                    foreach (var additionalObject in blocksSection.AdditionalObjects)
+                    {
+                        if (additionalObject != null && addedObjects.Add(additionalObject))
+                        {
+                            Objects.Add(additionalObject);
+                        }
+                    }
+                }
             }
         }
 
@@ -585,7 +598,7 @@ namespace IxMilia.Dxf
         }
 
         private static void AddMissingTableItems<T>(HashSet<string> existingItems, IEnumerable<string> itemsToAdd, Func<string, T> createItem, Action<T> addItem)
-            where T: DxfSymbolTableFlags
+            where T : DxfSymbolTableFlags
         {
             AddMissingItems(existingItems, itemsToAdd, name => addItem(createItem(name)));
         }

--- a/src/IxMilia.Dxf/Sections/DxfBlocksSection.cs
+++ b/src/IxMilia.Dxf/Sections/DxfBlocksSection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using IxMilia.Dxf.Blocks;
 using IxMilia.Dxf.Collections;
+using IxMilia.Dxf.Objects;
 
 namespace IxMilia.Dxf.Sections
 {
@@ -10,9 +11,12 @@ namespace IxMilia.Dxf.Sections
     {
         public IList<DxfBlock> Blocks { get; }
 
+        public List<DxfObject> AdditionalObjects { get; }
+
         public DxfBlocksSection()
         {
             Blocks = new ListNonNull<DxfBlock>();
+            AdditionalObjects = new List<DxfObject>();
             Normalize();
         }
 
@@ -34,6 +38,7 @@ namespace IxMilia.Dxf.Sections
 
         protected internal override IEnumerable<DxfCodePair> GetSpecificPairs(DxfAcadVersion version, bool outputHandles, HashSet<IDxfItem> writtenItems)
         {
+            AdditionalObjects.Clear();
             foreach (var block in Blocks.Where(b => b != null))
             {
                 if (writtenItems.Add(block))
@@ -41,6 +46,11 @@ namespace IxMilia.Dxf.Sections
                     foreach (var pair in block.GetValuePairs(version, outputHandles))
                     {
                         yield return pair;
+                    }
+
+                    foreach (var entity in block.Entities)
+                    {
+                        entity.AddObjectsToOutput(AdditionalObjects);
                     }
                 }
             }


### PR DESCRIPTION
potential fix that is needed for image definitions of images inside blocks
otherwise images inside blocks are not displayed unless the definition is also used by an image in the files entities 

implementation for DxfBlocksSection was mostly copied from DxfEntitiesSection

i have checked that this works with LibreCad
it does not work with Creo Direct Draft because that piece of software does not support images in shared groups which has forced me to move all images to the root entities in my use case(making this fix unnecessary in my case)

i am not sure how widely images in blocks are supported(i do not have access to AutoCAD and images in this library are not compatible with it anyway) but if most viewers dont this fix might be unnecessary